### PR TITLE
Simplify session tagging system

### DIFF
--- a/TAGGING_REFACTOR_PLAN.md
+++ b/TAGGING_REFACTOR_PLAN.md
@@ -1,0 +1,72 @@
+# Session Tagging Refactor Plan
+
+This document outlines the implementation plan to refactor the session tagging system. The goal is to move from a "duplicated session" model to a more efficient relational model where a single session record is associated with multiple participants.
+
+## Guiding Principles
+
+1.  **Single Source of Truth**: A surf session will be a single record in the database. The concept of creating duplicate sessions for each participant will be eliminated.
+2.  **Relational Participants**: Tagged users will be associated with a session via a direct foreign key relationship in the `session_participants` table.
+3.  **Creator-Centric Logic**: All edit/delete permissions and primary visibility will be based on the `user_id` of the session creator.
+4.  **No Data Migration**: This refactor applies only to new sessions. Existing data and database schema will not be migrated or altered.
+
+---
+
+## Database Strategy: The `session_group_id` Column
+
+-   **No Schema Change**: The database schema will **not** be altered. The `session_participants` table already exists and will be used as the primary source for participant data.
+-   **Handling `session_group_id`**: The `session_group_id` column in the `surf_sessions_duplicate` table is now obsolete for new sessions. However, it will be left in the database to maintain the integrity of existing data. For all sessions created after this refactor, the `session_group_id` will be `NULL`.
+
+---
+
+## Implementation Tasks
+
+### Part 1: Database Logic Simplification (`database_utils.py`)
+
+This phase focuses on changing how session and participant data is written to the database.
+
+-   **Task 1.1: Refactor `create_session_with_participants`**
+    -   **File to Modify**: `database_utils.py`
+    -   **Action**: The function will be rewritten to perform the following steps in a single transaction:
+        1.  Remove the logic that generates a `session_group_id`.
+        2.  Call the standard `create_session` function to insert a single record into `surf_sessions_duplicate` for the creator. The `session_group_id` will not be included.
+        3.  Using the `id` returned from the newly created session, insert one row into the `session_participants` table for the creator.
+        4.  Iterate through the `tagged_user_ids` array and insert one row into `session_participants` for each tagged user, linking them to the same session `id`.
+
+-   **Task 1.2: Remove Redundant Code**
+    -   **File to Modify**: `database_utils.py`
+    -   **Action**: Delete the `create_duplicate_session` function, as it is no longer needed.
+    -   **Action**: Remove any logic for manually calculating `next_id` within the participant creation flow.
+
+### Part 2: API and Data Retrieval Adjustments
+
+This phase ensures the API endpoints and data retrieval queries align with the new, simplified data structure.
+
+-   **Task 2.1: Simplify `create_surf_session` Endpoint**
+    -   **File to Modify**: `surfdata.py`
+    -   **Action**: The JSON response for a successful session creation with participants will be simplified. It will now return the `session_id` of the single session created and a simple list of the user IDs that were successfully tagged.
+
+-   **Task 2.2: Refactor Data Retrieval Queries**
+    -   **File to Modify**: `database_utils.py`
+    -   **Action**: The SQL queries within `get_all_sessions`, `get_user_sessions`, and `get_session` will be modified. The current complex self-join on `session_group_id` will be replaced with a more efficient `LEFT JOIN` on the `session_participants` table, grouping by the session ID to aggregate the list of participants.
+
+---
+
+## Summary of File Modifications
+
+-   **MODIFIED**: `database_utils.py` (Core logic change, function removal, query updates)
+-   **MODIFIED**: `surfdata.py` (Simplified API response)
+
+---
+
+## Success Criteria & Verification
+
+The refactor will be considered successful when the following conditions are met:
+
+1.  **Session Creation**: A `POST` request to `/api/surf-sessions` with a `tagged_users` array results in:
+    -   Only **one** new row being created in the `surf_sessions_duplicate` table.
+    -   The `session_participants` table containing a row for the creator and each tagged user, all linked to the single new session ID.
+
+2.  **Session Retrieval**: A `GET` request to `/api/surf-sessions/<session_id>` for the newly created session returns a JSON object where:
+    -   The `participants` array is correctly populated with the creator and all tagged users, based on the data in the `session_participants` table.
+
+3.  **Application Stability**: The application runs without errors, and all other API endpoints function as expected.

--- a/surfdata.py
+++ b/surfdata.py
@@ -322,30 +322,23 @@ def create_surf_session(user_id):
             result = create_session_with_participants(session_data, user_id, tagged_users)
             
             if result:
-                created_sessions = result['sessions']
+                created_session = result['session']
                 participants = result['participants']
-                session_group_id = result['session_group_id']
                 
-                # Return enhanced response with tagging information
+                # Return simplified response
                 return jsonify({
                     "status": "success",
-                    "message": f"Surf session created successfully with {len(tagged_users)} tagged participants",
+                    "message": f"Surf session created successfully with {len(participants) - 1} tagged participants",
                     "data": {
-                        "session_group_id": session_group_id,
-                        "sessions_created": len(created_sessions),
-                        "original_session_id": created_sessions[0]["id"],
-                        "tagged_sessions": [
-                            {"session_id": s["id"], "user_id": s["user_id"]} 
-                            for s in created_sessions[1:]
-                        ],
-                        "participants": len(participants),
-                        "location": session_data['location'],
+                        "session_id": created_session["id"],
+                        "location": created_session['location'],
                         "date": session_date,
                         "time": session_time,
                         "end_time": end_time,
                         "swell_buoy_id": session_data.get('swell_buoy_id'),
                         "met_buoy_id": session_data.get('met_buoy_id'),
-                        "tide_station_id": session_data.get('tide_station_id')
+                        "tide_station_id": session_data.get('tide_station_id'),
+                        "participants": [p['user_id'] for p in participants]
                     }
                 }), 200
             else:


### PR DESCRIPTION
This basically does the following: 
- creating sess a session with participants now only creates 1 session. It no longer duplicates
- get all sessions, get user sessions, get session have been updated as well  

Some notes / decisions on the backend: 
- session participants are stored in a separate "session_participants" table
- This is an example of a relational database
- This is because it allows for more efficient querying in the future and is more flexible 
- For example: One thing to consider is whether or not "My Journal" should include sessions you were tagged in (but have not created for yourself) 
-              I assumed the answer is no for now; you would only want to see sessions you created yourself (at least for MVP 0) 
-              However, in the future we might want to be able to quickly query if you were tagged, and include that in your journal 

### GEMINI description: 
 Title: Refactor: Simplify Session Tagging System to Relational Model

  **Description:**


  This pull request implements a significant refactor of the session tagging feature. It replaces the inefficient "session duplication" system
  with a standard, relational database model. This change improves performance, ensures data integrity, and makes the codebase easier to
  maintain.

  **The Problem with the Old System**

  The previous implementation created a full copy of a surf session for every user who was tagged. While functional, this led to redundant data
  and complex queries that had to join the sessions table to itself using a session_group_id.

  **The New Approach: Why We Use Two Tables**


  This PR adopts a standard database design pattern. Instead of storing a simple list of participants in a single column, we use two tables:
  surf_sessions_duplicate and session_participants. This might seem more complex, but it is the professional standard for several critical
  reasons:


   1. Efficient Querying: It allows us to answer crucial questions very quickly. For example, finding all sessions a specific user participated in
      is now a simple, fast database JOIN operation, which is what relational databases are optimized for. With a single column, we would have to
      manually search inside a text/JSON field for every row, which is extremely slow and doesn't scale.


   2. Data Integrity: The session_participants table uses foreign keys. This means the database guarantees that every participant record is linked
      to a real session and a real user. If a user deletes their account, the database can automatically handle these links, preventing "orphaned"
      data and potential application errors.


   3. Extensibility: This model is easy to extend. If we ever want to add more information about a tag (e.g., if the user has "accepted" the tag, or
      the time they were tagged), we can simply add a new column to the session_participants table without disrupting the rest of the system.

  **Implementation Details**


   - `database_utils.py`:
       - The create_session_with_participants function has been rewritten. It now creates only one session and then adds a row to the
         session_participants table for the creator and each tagged user.
       - The obsolete create_duplicate_session function has been removed.
       - All data retrieval queries (get_all_sessions, get_user_sessions, get_session) have been updated to use a standard LEFT JOIN on the
         session_participants table.
       - A final safeguard was added to the create_session function to ensure the session_group_id column is never populated for new sessions.

   - `surfdata.py`:
       - The API response for creating a session with tagged users has been simplified to reflect the new, single-session model.

  **How to Test**


   1. Make a POST request to /api/surf-sessions with a tagged_users array.
   2. Verify in the database that only one new row was created in the surf_sessions_duplicate table and that its session_group_id is NULL.
   3. Verify that the session_participants table has a new row for the creator and for each tagged user, all linked to the single new session ID.
   4. Make a GET request to /api/surf-sessions/<new_session_id> and confirm the participants array in the response is accurately populated with the
      correct users.
 