### PR TITLE
Feat: Shaka Reactions

### DIFF
--- a/GEMINI_CONTEXT.md
+++ b/GEMINI_CONTEXT.md
@@ -6,48 +6,37 @@ This document summarizes the current architecture and key features of the Surf A
 
 The application is a full-stack surf logging and forecasting platform. The backend is a Python Flask application that serves a JSON API consumed by a frontend client.
 
--   **Backend (`surfdata.py`)**: The core of the application is a **Flask API**. It handles all incoming requests, user authentication, and API routing. It uses `Flask-Caching` for performance on data-intensive endpoints like the forecast.
+-   **Backend (`surfdata.py`)**: The core of the application is a **Flask API**. It handles all incoming requests, user authentication, and API routing. It uses `Flask-Caching` for performance on data-intensive endpoints.
 
--   **Database (`database_utils.py`)**: All persistent data is stored in a **PostgreSQL** database, managed via the `database_utils.py` module. This module uses the `psycopg2` library to interact with the database. Key tables include `surf_sessions_duplicate` for session logs, `auth.users` for user data, and `surf_spots` for location configurations.
+-   **Database (`database_utils.py`)**: All persistent data is stored in a **PostgreSQL** database, managed via the `database_utils.py` module. This module uses the `psycopg2` library to interact with the database. Key tables include `surf_sessions_duplicate` for session logs, `auth.users` for user data, `surf_spots` for location configurations, and `session_participants` for tagging.
 
--   **Data Abstraction Layer (`ocean_data/`)**: This Python package serves as a high-level interface for all external oceanographic data. It abstracts the complexities of fetching and processing data, providing simple functions like `get_surf_forecast` and `fetch_swell_data` to the main application. It is responsible for orchestrating data from various sources.
+-   **Data Abstraction Layer (`ocean_data/`)**: This Python package serves as a high-level interface for all external oceanographic data. It abstracts the complexities of fetching and processing data, providing simple functions like `fetch_swell_data` to the main application.
 
--   **Core Data Engine (`surfpy/`)**: This is a powerful, low-level library that acts as the engine for all data fetching and processing. It interfaces directly with external data sources:
-    -   **NDBC Buoys**: Fetches real-time meteorological data, wave spectra, and pre-computed GFS wave model forecast bulletins via `surfpy/buoystation.py`.
-    -   **NOAA Tide Stations**: Fetches tide predictions from the NOAA Tides and Currents API via `surfpy/tidestation.py`.
-    -   **Weather Models**: Contains logic to interact with weather APIs (`weatherapi.py`) and parse GRIB data from models like GFS (`wavemodel.py`, `weathermodel.py`).
+-   **Core Data Engine (`surfpy/`)**: This is a powerful, low-level library that acts as the engine for all data fetching and processing. It interfaces directly with external data sources like NOAA buoys and tide stations.
 
 ## 2. Core Features & Data Flow
 
 ### a. User Authentication & Management
--   **Auth**: User signup and login are handled via Supabase's REST API, as seen in the `/api/auth/signup` and `/api/auth/login` endpoints in `surfdata.py`.
--   **Authorization**: API endpoints are protected using a JWT-based `@token_required` decorator, which validates the user's access token.
+-   **Auth**: User signup and login are handled via Supabase's REST API.
+-   **Authorization**: API endpoints are protected using a JWT-based `@token_required` decorator.
 -   **User Search**: The `/api/users/search` endpoint allows for finding other users on the platform.
 
 ### b. Surf Session Logging (CRUD)
--   **Flow**: When a user logs a session via a `POST` to `/api/surf-sessions`, the backend:
-    1.  Validates the user's token and input data.
-    2.  Uses `ocean_data.location.get_spot_config` to retrieve the correct buoy and tide station IDs from the `surf_spots` database table.
-    3.  Calls the `ocean_data` package to fetch the historical swell, meteorological, and tide data for the session's time and location.
-    4.  Saves the complete session object, including the raw ocean data, to the database using `database_utils.create_session`.
--   **Social Tagging**: Users can tag friends in a session, which creates duplicate session entries for each tagged user, linked by a `session_group_id`.
-
-### c. 7-Day Surf Forecast
--   **Endpoint**: A cached `/api/forecast/<spot_name>` endpoint provides a detailed 7-day, hour-by-hour surf forecast.
--   **Data Flow**:
-    1.  A request hits the endpoint. The system checks for a fresh (<1 hour) cached forecast.
-    2.  If no cache exists, `ocean_data.forecast.get_surf_forecast` is called.
-    3.  It retrieves the spot's configuration (buoy IDs, breaking wave parameters) from the database.
-    4.  It fetches **historical "actuals"** for the last 24 hours from the NDBC buoy data.
-    5.  It fetches **future "forecasts"** by downloading and parsing a GFS wave model **bulletin** from the NOAA website.
-    6.  It fetches tide and wind forecasts from the respective APIs.
-    7.  The data is resampled into a clean hourly grid, combining actuals and forecasts.
-    8.  **Breaking wave height** is calculated for each hour using the spot's specific bathymetry parameters (`depth`, `angle`, `slope`).
-    9.  The final JSON is formatted, cached, and returned to the user.
+-   **Flow**: When a user logs a session, the backend fetches the relevant historical swell, meteorological, and tide data and saves it to the database with the session details.
+-   **Relational Session Tagging**: The application uses a relational model for tagging users in a session. Instead of duplicating sessions, a single session record is created, and all participants (the creator and tagged users) are linked to it via records in the `session_participants` table. This approach ensures data integrity, simplifies queries, and is highly scalable.
 
 ## 3. Key Technical Decisions & Concepts
 
--   **Database-Driven Configuration**: The application has evolved from hardcoded dictionaries to a database-centric approach. All surf spot configurations, including names, slugs, data source IDs, and breaking wave parameters, are stored in the `surf_spots` table. This makes the system more scalable and easier to manage.
--   **Hybrid Forecast Model**: The forecast intelligently combines real-world historical data ("actuals") with model-based forecast data to provide a seamless timeline from the past into the future.
--   **Breaking Wave Height**: This is a core value proposition. The system uses `surfpy`'s physics-based calculations to translate offshore swell energy into a user-friendly breaking wave height range (e.g., "2-3 ft") based on location-specific parameters.
+-   **Database-Driven Configuration**: All surf spot configurations, including names, slugs, data source IDs, and breaking wave parameters, are stored in the `surf_spots` database table. This makes the system scalable and easy to manage.
+
+-   **Relational Data Model**: The session tagging feature was explicitly refactored from a data duplication model to a proper relational model using the `session_participants` table. This was done to ensure data integrity via foreign keys and to allow for efficient, scalable querying.
+
 -   **Backward Compatibility**: The use of a `LEGACY_LOCATION_MAP` in `ocean_data/location.py` ensures that older API clients or bookmarks still function even though the location management system has been updated.
+
+## 4. Archived Features
+
+This section documents features that were previously implemented but have been removed from the active codebase. The code for these features is preserved in the `archives/` directory for potential future use.
+
+### a. 7-Day Surf Forecast
+-   **Status**: Removed from the backend API. The core logic file (`ocean_data/forecast.py`) has been moved to `archives/forecast_logic/ocean_data/`.
+-   **Original Implementation**: The feature provided a 7-day, hour-by-hour surf forecast via a cached `/api/forecast/<spot_name>` endpoint. It worked by combining historical "actuals" from buoy readings with future "forecasts" from GFS wave model bulletins. It also calculated the breaking wave height for each spot based on its specific bathymetry.

--- a/GEMINI_CONTEXT.md
+++ b/GEMINI_CONTEXT.md
@@ -8,7 +8,7 @@ The application is a full-stack surf logging and forecasting platform. The backe
 
 -   **Backend (`surfdata.py`)**: The core of the application is a **Flask API**. It handles all incoming requests, user authentication, and API routing. It uses `Flask-Caching` for performance on data-intensive endpoints.
 
--   **Database (`database_utils.py`)**: All persistent data is stored in a **PostgreSQL** database, managed via the `database_utils.py` module. This module uses the `psycopg2` library to interact with the database. Key tables include `surf_sessions_duplicate` for session logs, `auth.users` for user data, `surf_spots` for location configurations, and `session_participants` for tagging.
+-   **Database (`database_utils.py`)**: All persistent data is stored in a **PostgreSQL** database, managed via the `database_utils.py` module. This module uses the `psycopg2` library to interact with the database. Key tables include `surf_sessions_duplicate` for session logs, `auth.users` for user data, `surf_spots` for location configurations, `session_participants` for tagging, and `session_shakas` for reactions.
 
 -   **Data Abstraction Layer (`ocean_data/`)**: This Python package serves as a high-level interface for all external oceanographic data. It abstracts the complexities of fetching and processing data, providing simple functions like `fetch_swell_data` to the main application.
 
@@ -24,6 +24,7 @@ The application is a full-stack surf logging and forecasting platform. The backe
 ### b. Surf Session Logging (CRUD)
 -   **Flow**: When a user logs a session, the backend fetches the relevant historical swell, meteorological, and tide data and saves it to the database with the session details.
 -   **Relational Session Tagging**: The application uses a relational model for tagging users in a session. Instead of duplicating sessions, a single session record is created, and all participants (the creator and tagged users) are linked to it via records in the `session_participants` table. This approach ensures data integrity, simplifies queries, and is highly scalable.
+-   **Shaka Reactions**: Users can give a "shaka" to any surf session. This is handled by a `POST /api/surf-sessions/<session_id>/shaka` endpoint that toggles the reaction. All session retrieval endpoints now include a `shakas` object containing the total count, a preview of users who have reacted, and a `viewer_has_shakaed` boolean flag.
 
 ## 3. Key Technical Decisions & Concepts
 

--- a/SHAKA_FEATURE_PLAN.md
+++ b/SHAKA_FEATURE_PLAN.md
@@ -1,0 +1,65 @@
+# "Shaka" Reacts Feature Implementation Plan
+
+This document outlines the implementation plan for adding a "shaka" reaction feature to surf sessions. It details the database schema that will be created manually and the backend logic that will be implemented to support the feature.
+
+---
+
+## Part 1: Database Schema (Manual Creation)
+
+This section provides the required schema for the new `session_shakas` table. **This table will be created manually in the Supabase UI.** The backend logic will be written with the expectation that this exact schema is in place.
+
+**Table Name:** `session_shakas`
+
+**Columns:**
+
+| Column Name  | Data Type     | Constraints & Default Value                                  | Notes                                                                                             |
+| :----------- | :------------ | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
+| `session_id` | `int8`        | `NOT NULL`                                                   | This will be a Foreign Key referencing `surf_sessions_duplicate(id)`. Set `ON DELETE` to **Cascade**. |
+| `user_id`    | `uuid`        | `NOT NULL`                                                   | This will be a Foreign Key referencing `auth.users(id)`. Set `ON DELETE` to **Cascade**.          |
+| `created_at` | `timestamptz` | `NOT NULL`, Default: `now()`                                 | Records when the shaka was given.                                                                 |
+
+**Primary Key:**
+
+-   The primary key must be a **composite key** consisting of both the `session_id` and `user_id` columns. This is critical as it prevents a user from liking the same session more than once.
+
+**Row Level Security (RLS):**
+
+-   It is highly recommended that you **enable Row Level Security (RLS)** on this new table. You can start with permissive policies (e.g., allowing logged-in users to `INSERT` and `DELETE` their own shakas) and refine them later as needed.
+
+---
+
+## Part 2: Backend API Implementation
+
+1.  **Create "Toggle Shaka" Endpoint:**
+    -   **Endpoint:** `POST /api/surf-sessions/<int:session_id>/shaka`
+    -   **Logic:** A new function will be created in `database_utils.py` to handle the "toggle" logic. It will attempt to `INSERT` a new shaka record. If the database returns a primary key violation error (because the record already exists), it will then `DELETE` the record instead.
+    -   **Response:** The endpoint will return the new total shaka count for the session.
+
+2.  **Update Data Retrieval Queries:**
+    -   **File to Modify:** `database_utils.py`
+    -   **Action:** The SQL queries in `get_all_sessions`, `get_user_sessions`, and `get_session` will be modified to include a subquery or a `LEFT JOIN` to accomplish the following for each session:
+        a.  Calculates the total count of shakas (`shaka_count`).
+        b.  Aggregates a JSON array of a preview of users who have given a shaka (`shakas_preview`).
+        c.  Includes a boolean flag (`viewer_has_shakaed`) that is `true` if the `user_id` of the person making the request is in the list of shakas for that session.
+
+---
+
+## Part 3: API Response Structure
+
+The JSON object for each session returned by the API will be enhanced to include a new `shakas` object, structured as follows:
+
+```json
+{
+  "id": 123,
+  "location": "Lido Beach",
+  // ... other session data
+  "shakas": {
+    "count": 5,
+    "viewer_has_shakaed": true,
+    "preview": [
+      { "user_id": "uuid-stefano", "display_name": "Stefano" },
+      { "user_id": "uuid-friend1", "display_name": "Friend A" }
+    ]
+  }
+}
+```


### PR DESCRIPTION
### I did the following: 
**Database update**
1. Created new table in database "session_shakas." It links to the sessions table and the user id
2. Each row represents someone liking a session

**Endpoint creation**
1. Created a new endpoint "toggle_shaka_route" 
2. The toggle is basically a button -- a user hits it to add a like and also remove a like. 
3. Gemini suggested using a toggle endpoint, rather than having 3 distinct post, get, and delete shaka endpoints. That way, the frontend only has to handle 1 endpoint, which will make it easier on 'ole v0

**Endpoint modification**
1. The session retrieval endpoints now return the number of shakas, the people who have shaka'd, and if the current user has shaka'd (this allows the toggle to work)

**Testing**
1. I tested in Postman via the following format: http://127.0.0.1:5000/api/surf-sessions/<int:session_id>/shaka

**Project management**
1. Updated Gemini context file with this new information
2. There's also the Shaka feature plan file

### Gemini explanation

Body:

  This pull request introduces the "Shaka" reaction feature, allowing users to like and react to surf sessions. The implementation follows the technical specification outlined
   in SHAKA_FEATURE_PLAN.md.

  Key Changes:

   * New Shaka Endpoint: A new POST /api/surf-sessions/<int:session_id>/shaka endpoint has been created. This endpoint handles the toggle logic, allowing a user to add or
     remove a "shaka" from a session with a single API call.
   * Enhanced Session Data: All API endpoints that return session data (e.g., GET /api/surf-sessions, GET /api/surf-sessions/<id>) have been updated. The JSON response for
     each session now includes a shakas object with the following structure:

   1     "shakas": {
   2       "count": 1,
   3       "viewer_has_shakaed": true,
   4       "preview": [
   5         { "user_id": "...", "display_name": "..." }
   6       ]
   7     }
   * Bug Fixes: During implementation, a recurring TypeError was identified and fixed across all session retrieval functions (get_all_sessions, get_session, etc.). The issue
     was caused by the new requirement to pass the current_user_id to the database layer to determine the viewer_has_shakaed status.

  Testing:

  The new endpoint and all modified session retrieval endpoints were tested manually using Postman. The tests confirmed that the toggle functionality works as expected and
  that the session data is correctly updated with the shaka information.

