### PR TITLE
Fixed CORS authorization header issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytz
 PyJWT
 Flask-Caching
 noaa-coops
+flask-cors

--- a/surfdata.py
+++ b/surfdata.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify, request
+from flask_cors import CORS
 from flask_caching import Cache
 from datetime import datetime, timezone, timedelta
 import surfpy
@@ -20,6 +21,13 @@ from ocean_data.tide import fetch_tide_data
 from ocean_data.location import get_buoys_for_location, is_valid_location, get_spot_config
 
 app = Flask(__name__)
+
+#CORS configuration
+CORS(app, 
+     origins=["*"],  # Allows all origins
+     allow_headers=["Content-Type", "Authorization"],
+     methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+     supports_credentials=True)
 
 # Configure caching
 app.config['CACHE_TYPE'] = 'SimpleCache'  # In-memory cache


### PR DESCRIPTION
### Basically
- Added in a couple lines of code that lets v0 communicate with our backend more effectively 
- You'll need to run pip install flask-cors

### Here's the full Claude explanation: 
**Problem**
The frontend app was unable to communicate with our Flask API due to a CORS (Cross-Origin Resource Sharing) error. Specifically, the browser was blocking requests because our API wasn't configured to accept the Authorization header that contains user login tokens.

**What is CORS and why did this happen?**
CORS is a security feature built into web browsers that prevents websites from making requests to different domains unless explicitly allowed. Think of it like a security guard at a building - by default, it blocks all visitors unless they're on an approved list.
In our case:

Frontend domain: https://preview-surf-logging-app-*.vusercontent.net (changes with each deployment)
Backend API domain: https://surfdata-*.vercel.app (our Flask API)

When our frontend tried to send user login tokens (in the Authorization header) to the API, the browser said "nope" because:

The domains are different (cross-origin request)
Our API wasn't configured to accept Authorization headers from other domains

**What we fixed**
Added CORS configuration to our Flask API that tells browsers:

✅ "It's okay to accept requests from any domain" (origins=["*"])
✅ "It's okay to send Authorization and Content-Type headers"
✅ "Allow GET, POST, PUT, DELETE methods"

**Changes made**

Added dependency: flask-cors to requirements.txt
Added CORS configuration to our Flask app that allows cross-origin requests with authorization headers

**Why this solution**

Simple: One configuration handles all CORS issues
Flexible: Works with Vercel's changing deployment URLs
Secure enough: Still validates authorization tokens on the server side
Standard practice: Using the official Flask-CORS library

**Result**
Users can now successfully log in and make authenticated requests to the API without browser blocking the requests.

Note: In production, we should replace origins=["*"] with specific allowed domains for better security.