### PR TITLE
Timezone refactoring

### DIFF
--- a/TIMEZONE_REFACTOR_PLAN.md
+++ b/TIMEZONE_REFACTOR_PLAN.md
@@ -1,0 +1,45 @@
+# Timezone Handling Refactoring Plan
+
+This document outlines the plan to refactor the application's timezone handling to ensure consistency, eliminate ambiguity, and align with modern API best practices.
+
+## 1. The Goal: Standardization and Unambiguity
+
+The primary goal is to standardize how time-based data is stored, processed, and returned. All session-related timestamps will be handled as absolute points in time, normalized to UTC.
+
+-   **Storage:** All timestamps will be stored in the database in `TIMESTAMP WITH TIME ZONE` columns, which PostgreSQL stores as UTC.
+-   **Processing:** All backend logic will operate on UTC timestamps.
+-   **API Response:** All API endpoints will return timestamps in the ISO 8601 format with the UTC "Z" designator (e.g., `2025-08-07T00:00:00Z`).
+
+## 2. The Problem
+
+Currently, session times are stored as naive `date` and `time` columns, which is ambiguous. While the backend correctly converts these to UTC for data fetching, the stored values and API responses are inconsistent. This plan will fix that.
+
+## 3. The Refactoring Plan
+
+### Step 1: Refactor the Database Schema
+
+The `surf_sessions_duplicate` table will be modified to store session times unambiguously.
+
+-   **Action:**
+    1.  Add two new columns:
+        -   `session_started_at` (type: `TIMESTAMP WITH TIME ZONE`)
+        -   `session_ended_at` (type: `TIMESTAMP WITH TIME ZONE`)
+    2.  Create a migration script to populate these new columns based on the existing `date` and `time` values and the timezone of the corresponding surf spot.
+    3.  Remove the old, naive columns: `date`, `time`, and `end_time`.
+
+### Step 2: Update the Backend Logic
+
+The Flask API will be updated to work with the new schema.
+
+-   **On `CREATE` and `UPDATE` (`/api/surf-sessions`):**
+    -   The logic will continue to accept the user's naive `date`, `time`, and `end_time` from the request body for backward compatibility.
+    -   It will use the `spot_config['timezone']` to convert these inputs into timezone-aware `datetime` objects.
+    -   It will save these `datetime` objects into the new `session_started_at` and `session_ended_at` columns.
+
+-   **On `GET` (All session retrieval endpoints):**
+    -   In `database_utils.py`, when preparing session data for the response, explicitly format **all** timestamp fields (`session_started_at`, `session_ended_at`, `created_at`, and `next_tide_event_at`) into full ISO 8601 UTC strings.
+    -   Ensure the surf spot's `timezone` string (e.g., "America/New_York") is included in the session's JSON response so the client can correctly display the time in the spot's local timezone.
+
+## 4. Expected Outcome
+
+After this refactoring, every time-related field returned by the API for a surf session will be a full, unambiguous UTC timestamp. This will give the frontend maximum flexibility for display and make the entire system more robust and maintainable.


### PR DESCRIPTION
### How timezone is handled now: 
- User enters in a date, time, and location
- this is converted to UTC
- all data processing is done in UTC
- all get sessions return data in UTC + timezone
- Front end will handle timezone conversion

Achieving this required two new database columns: Session_started_at and session_ended_at, which are timezone aware

**Full details from Gemini below:** 

 This pull request resolves the issue of inconsistent timezone handling across the API by implementing a clear and robust strategy for storing,
  processing, and returning time-based data.

  **Background:**

  The get_sessions endpoint and others were returning data with mixed timezone formats. While the times were technically correct, the lack of a
  uniform standard made client-side handling difficult and prone to errors. This work establishes a clear, consistent system.

  **Implementation Details:**

  This PR addresses the required tasks by:

   1. Defining a Conversion Strategy: The strategy is now simple and explicit:
       * All time-based data is processed and stored in UTC.
       * The API returns only UTC timestamps (as ISO 8601 strings).
       * The client is responsible for converting these UTC timestamps to the appropriate local time for display, using the timezone field
         provided in the surf spot configuration.

   2. Updating Database Storage:
       * The naive date, time, and end_time columns have been replaced with two new, timezone-aware columns: session_started_at and
         session_ended_at (type: TIMESTAMP WITH TIME ZONE). This ensures all session times are stored unambiguously as absolute points in time.

   3. Uniform Endpoint Handling:
       * All session-related endpoints (/api/surf-sessions, /api/surf-sessions/<id>, etc.) have been refactored to use a central
         _format_session_response helper.
       * This guarantees that every timestamp in the API response is a full ISO 8601 UTC string and that the overall session object has a
         consistent structure.

   4. Updating Session Creation/Update Logic:
       * The create_surf_session and update_surf_session endpoints now correctly convert the incoming naive local time from the user into a UTC
         timestamp before saving it to the database.

   5. Verifying Oceanographic Data Fetching:
       * Confirmed that the logic for fetching swell, tide, and meteorological data was already correctly converting the session time to UTC
         before making requests to external services. This logic remains correct and is now more robust with the standardized timestamps.

  **Acceptance Criteria Checklist:**

   * [x] All database times stored in UTC: Achieved via the schema migration to TIMESTAMP WITH TIME ZONE columns.
   * [x] Clear, documented conversion points between UTC and local time: The conversion from local to UTC happens upon receiving user input in the
     API. The API now speaks exclusively in UTC to the client.
   * [x] Consistent timezone handling across all session-related endpoints: Achieved by using the central formatting function and returning only
     ISO 8601 UTC strings for all timestamp fields.

  **BREAKING CHANGE:**

  The structure of the session object returned by all /api/surf-sessions endpoints has changed.

   * The date, time, and end_time fields have been removed.
   * They are replaced by session_started_at and session_ended_at (ISO 8601 UTC strings).
   * Several top-level tide fields are now nested within a tide object for better organization.

  Frontend clients must be updated to handle this new, more consistent data structure.

