### PR TITLE
Support multi views

### DIFF
--- a/GEMINI_CONTEXT.md
+++ b/GEMINI_CONTEXT.md
@@ -32,7 +32,13 @@ The application is a full-stack surf logging and forecasting platform. The backe
 
 -   **Relational Data Model**: The session tagging feature was explicitly refactored from a data duplication model to a proper relational model using the `session_participants` table. This was done to ensure data integrity via foreign keys and to allow for efficient, scalable querying.
 
+-   **Timezone Handling**: All session timestamps are now stored in the database as timezone-aware UTC (`TIMESTAMP WITH TIME ZONE`). The API consistently returns these as ISO 8601 UTC strings, with the client responsible for local time display. This ensures unambiguous time representation across the system.
+
 -   **Backward Compatibility**: The use of a `LEGACY_LOCATION_MAP` in `ocean_data/location.py` ensures that older API clients or bookmarks still function even though the location management system has been updated.
+
+### c. Lightweight Session Endpoints & Filtering
+-   **Performance Optimization**: Session list views (main feed, user journals) now utilize lightweight API responses, excluding large `raw_swell`, `raw_met`, and detailed tide data. This significantly improves frontend performance.
+-   **Server-Side Filtering**: These lightweight endpoints support server-side filtering by swell height, period, and direction, ensuring only relevant data is transferred. The regional filter is planned for a future iteration.
 
 ## 4. Archived Features
 

--- a/LIGHTWEIGHT_ENDPOINTS_PLAN.md
+++ b/LIGHTWEIGHT_ENDPOINTS_PLAN.md
@@ -68,10 +68,8 @@ This view will return the complete session object, including all the detailed oc
 
 ## 3. Filtering Strategy (Server-Side)
 
-The lightweight list endpoints will support the following query parameters for filtering. The database will perform the filtering, and only the matching results will be returned.
+The lightweight list endpoints support the following query parameters for filtering. The database performs the filtering, and only the matching results are returned.
 
--   **Surf Region:**
-    -   `?region=<region-slug>` (e.g., `?region=east-coast`)
 -   **Swell Height (in feet):**
     -   `?min_swell_height=<number>`
     -   `?max_swell_height=<number>`
@@ -79,7 +77,13 @@ The lightweight list endpoints will support the following query parameters for f
     -   `?min_swell_period=<number>`
     -   `?max_swell_period=<number>`
 -   **Swell Direction:**
-    -   `?swell_direction=<cardinal>` (e.g., `N`, `SW`, `W`, `NNE`). The backend will map this to the correct degree range for the query.
+    -   `?swell_direction=<cardinal>` (e.g., `N`, `SW`, `W`, `NNE`). The backend maps this to the correct degree range for the query.
+
+### Outstanding Work: Regional Filter
+
+-   **Surf Region:**
+    -   `?region=<region-slug>` (e.g., `?region=east-coast`)
+    -   **Status:** This filter is currently not implemented. It requires joining the `surf_sessions_duplicate` table with the `surf_spots` table on `s.location = sp.name` and then filtering by `sp.region`. This will be addressed in a future iteration.
 
 ## 4. Backend Implementation Plan
 

--- a/LIGHTWEIGHT_ENDPOINTS_PLAN.md
+++ b/LIGHTWEIGHT_ENDPOINTS_PLAN.md
@@ -1,0 +1,116 @@
+# Lightweight Session Endpoints Refactoring Plan
+
+## 1. Background & Goal
+
+To improve frontend performance and create a faster user experience, we need to reduce the amount of data sent to list views like the main feed and user journals. These views do not require the large `raw_swell` and `raw_met` JSON objects.
+
+The goal is to refactor the session endpoints to provide two distinct views:
+1.  A **lightweight summary view** for lists (feeds, journals).
+2.  A **full detail view** for a single session page.
+
+This will be achieved by making the filtering logic server-side, ensuring that the client only ever receives the data it needs.
+
+## 2. API Endpoint Strategy
+
+The `view` will be determined by the endpoint called, not by a query parameter.
+
+### a. Lightweight List Endpoints
+
+These endpoints will always return a lightweight array of session objects, excluding the `raw_swell` and `raw_met` fields. They will, however, support server-side filtering based on parameters from those raw fields.
+
+-   **Main Feed:** `GET /api/surf-sessions`
+-   **Journal View:** `GET /api/users/{user_id}/sessions` (and its `me` alias)
+
+### b. Full Detail Endpoint
+
+This endpoint's behavior will not change. It will always return the complete session object with all fields, including `raw_swell` and `raw_met`.
+
+-   **Session Detail:** `GET /api/surf-sessions/{id}`
+
+## 2.5. API Response Fields
+
+To ensure clarity, the exact data contract for each view is defined below.
+
+### a. Lightweight Summary View (`/api/surf-sessions` and `/api/users/.../sessions`)
+
+This view is designed for speed and will include only the essential data needed to render a list item in a feed or journal.
+
+**Included Fields:**
+*   `id`
+*   `session_started_at` (ISO 8601 UTC String)
+*   `session_ended_at` (ISO 8601 UTC String)
+*   `created_at` (ISO 8601 UTC String)
+*   `location`
+*   `session_name`
+*   `session_notes`
+*   `fun_rating`
+*   `user_id`
+*   `display_name` (The creator's name)
+*   `user_email`
+*   `participants` (The lightweight list of tagged users)
+*   `shakas` (The object containing count, preview, and viewer status)
+
+**Specifically Excluded Fields:**
+*   `raw_swell`
+*   `raw_met`
+*   The entire `tide` object and its contents.
+
+### b. Full Detail View (`/api/surf-sessions/{id}`)
+
+This view will return the complete session object, including all the detailed oceanographic data needed for the session detail page.
+
+**Included Fields:**
+*   All fields from the **Lightweight Summary View**.
+*   **PLUS:**
+    *   `raw_swell` (The full JSONB object)
+    *   `raw_met` (The full JSONB object)
+    *   The complete `tide` object.
+
+## 3. Filtering Strategy (Server-Side)
+
+The lightweight list endpoints will support the following query parameters for filtering. The database will perform the filtering, and only the matching results will be returned.
+
+-   **Surf Region:**
+    -   `?region=<region-slug>` (e.g., `?region=east-coast`)
+-   **Swell Height (in feet):**
+    -   `?min_swell_height=<number>`
+    -   `?max_swell_height=<number>`
+-   **Swell Period (in seconds):**
+    -   `?min_swell_period=<number>`
+    -   `?max_swell_period=<number>`
+-   **Swell Direction:**
+    -   `?swell_direction=<cardinal>` (e.g., `N`, `SW`, `W`, `NNE`). The backend will map this to the correct degree range for the query.
+
+## 4. Backend Implementation Plan
+
+### a. `database_utils.py`
+
+We will create two distinct and clearly named functions:
+
+1.  **`get_session_detail(session_id, viewer_id)`**
+    -   **Purpose:** To fetch a single, complete session object.
+    -   **Details:** This will be a simple refactoring of the existing `get_session` function. It will `SELECT *` and return all fields.
+    -   **Called by:** `GET /api/surf-sessions/{id}`
+
+2.  **`get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})`**
+    -   **Purpose:** To fetch a filtered list of lightweight session summaries.
+    -   **Details:** This new function will be the core of the implementation.
+        -   The `SELECT` clause will explicitly list only the lightweight fields (no `raw_*` data).
+        -   It will contain logic to dynamically build a `WHERE` clause based on the `profile_user_id_filter` and the `filters` dictionary passed in from the API layer.
+        -   It will handle the logic for mapping cardinal swell directions to degree ranges.
+    -   **Called by:** `GET /api/surf-sessions` and `GET /api/users/{user_id}/sessions`.
+
+### b. `surfdata.py`
+
+The API endpoints will be simplified to call the appropriate new function from `database_utils`.
+
+-   The `get_surf_session` (by id) endpoint will call `get_session_detail`.
+-   The `get_surf_sessions` (all) and `get_user_journal_sessions` endpoints will parse the filter parameters from the request URL and pass them into the new `get_session_summary_list` function.
+
+## 5. Acceptance Criteria
+
+-   The main feed (`/api/surf-sessions`) loads quickly, returning a lightweight JSON payload.
+-   The journal views (`/api/users/.../sessions`) load quickly, returning a lightweight JSON payload.
+-   Both feed and journal views can be filtered by region, swell height, period, and direction.
+-   The session detail view (`/api/surf-sessions/{id}`) continues to return all oceanographic data.
+-   The backend code has a clear separation of concerns between the detail and summary list functions.

--- a/database_utils.py
+++ b/database_utils.py
@@ -766,6 +766,7 @@ def get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})
                     ) as shakas
                 FROM surf_sessions_duplicate s
                 LEFT JOIN auth.users u ON s.user_id = u.id
+                LEFT JOIN surf_spots sp ON s.location = sp.name
             """
             params = [viewer_id]
             where_clauses = []
@@ -817,6 +818,10 @@ def get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})
                     else:
                         where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'direction')::numeric BETWEEN %s AND %s")
                     params.extend([min_dir, max_dir])
+
+            if 'region' in filters:
+                where_clauses.append("sp.region ILIKE %s")
+                params.append(filters['region'])
 
             if where_clauses:
                 query += " WHERE " + " AND ".join(where_clauses)

--- a/database_utils.py
+++ b/database_utils.py
@@ -775,19 +775,19 @@ def get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})
                 params.append(profile_user_id_filter)
 
             if 'min_swell_height' in filters:
-                where_clauses.append("(s.raw_swell->'swell_components'->'swell_1'->>'height')::numeric >= %s")
+                where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'height')::numeric >= %s")
                 params.append(filters['min_swell_height'])
             
             if 'max_swell_height' in filters:
-                where_clauses.append("(s.raw_swell->'swell_components'->'swell_1'->>'height')::numeric <= %s")
+                where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'height')::numeric <= %s")
                 params.append(filters['max_swell_height'])
 
             if 'min_swell_period' in filters:
-                where_clauses.append("(s.raw_swell->'swell_components'->'swell_1'->>'period')::numeric >= %s")
+                where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'period')::numeric >= %s")
                 params.append(filters['min_swell_period'])
 
             if 'max_swell_period' in filters:
-                where_clauses.append("(s.raw_swell->'swell_components'->'swell_1'->>'period')::numeric <= %s")
+                where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'period')::numeric <= %s")
                 params.append(filters['max_swell_period'])
 
             if 'swell_direction' in filters:
@@ -813,9 +813,9 @@ def get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})
                 if direction in direction_map:
                     min_dir, max_dir = direction_map[direction]
                     if direction == 'N':
-                        where_clauses.append("((s.raw_swell->'swell_components'->'swell_1'->>'direction')::numeric >= %s OR (s.raw_swell->'swell_components'->'swell_1'->>'direction')::numeric < %s)")
+                        where_clauses.append("((s.raw_swell->0->'swell_components'->'swell_1'->>'direction')::numeric >= %s OR (s.raw_swell->0->'swell_components'->'swell_1'->>'direction')::numeric < %s)")
                     else:
-                        where_clauses.append("(s.raw_swell->'swell_components'->'swell_1'->>'direction')::numeric BETWEEN %s AND %s")
+                        where_clauses.append("(s.raw_swell->0->'swell_components'->'swell_1'->>'direction')::numeric BETWEEN %s AND %s")
                     params.extend([min_dir, max_dir])
 
             if where_clauses:

--- a/database_utils.py
+++ b/database_utils.py
@@ -36,18 +36,21 @@ def _format_session_response(session):
 
     # Group tide data into a single object
     tide_data = {}
-    if 'session_water_level' in session:
+    if 'session_water_level' in session and session.get('session_water_level') is not None:
         tide_data['water_level'] = session.pop('session_water_level')
-    if 'tide_direction' in session:
+    if 'tide_direction' in session and session.get('tide_direction') is not None:
         tide_data['direction'] = session.pop('tide_direction')
-    if 'next_tide_event_type' in session:
+    if 'next_tide_event_type' in session and session.get('next_tide_event_type') is not None:
         tide_data['next_event_type'] = session.pop('next_tide_event_type')
-    if 'next_tide_event_at' in session:
+    if 'next_tide_event_at' in session and session.get('next_tide_event_at') is not None:
         tide_data['next_event_at'] = session.pop('next_tide_event_at')
-    if 'next_tide_event_height' in session:
+    if 'next_tide_event_height' in session and session.get('next_tide_event_height') is not None:
         tide_data['next_event_height'] = session.pop('next_tide_event_height')
     
-    session['tide'] = tide_data
+    if tide_data:
+        session['tide'] = tide_data
+    else:
+        session.pop('tide', None)
 
     # Convert participants from JSONB array to Python list
     if 'participants' in session and session['participants']:


### PR DESCRIPTION
### Basically
- we have the same 3 get sessions functions -- get sessions (main feed), get user sessions, and get session_detail (renamed for clarity) 
- however, there is a new function "get summary list" that gets called by the get session and get user sessions endpoints -- this returns the lightweight session information 
- Additionally, this function supports "server-side filtering" based on query parameters for swell 1 height, period, and direction, and region
- Basically, the front end would pass the parameters to the endpoint, and the endpoint will return the filtered sessions (Rather than the frontend having to store and filter everything) 

### Full gemini explanation: 
  This pull request introduces significant performance improvements and enhanced filtering capabilities for session-related API endpoints, aligning with the goal of providing lightweight data for list views and full data for detail views.

  Key Changes Implemented:

   1. Dedicated Lightweight Session List Function (`get_session_summary_list`):
       * A new function, get_session_summary_list, has been created in database_utils.py. This function is optimized to select only the essential
         fields required for feed and journal views, explicitly excluding large raw_swell, raw_met, and detailed tide data.
       * This function now serves as the backend for both the main feed (/api/surf-sessions) and user journal views
         (/api/users/{user_id}/sessions).

   2. Server-Side Filtering for Lightweight Views:
       * The get_session_summary_list function now supports server-side filtering based on query parameters for:
           * Swell Height: min_swell_height, max_swell_height
           * Swell Period: min_swell_period, max_swell_period
           * Swell Direction: swell_direction (cardinal directions are mapped to degree ranges for database querying).
           * Region: based on region options in surf_spots

   3. Refactored API Endpoints (`surfdata.py`):
       * The /api/surf-sessions endpoint (main feed) now calls get_session_summary_list and passes through relevant filter parameters.
       * The /api/users/{user_id}/sessions endpoint (user journals) also calls get_session_summary_list, passing the user_id as a filter along
         with any other query parameters.
       * The single session detail endpoint (/api/surf-sessions/{id}) has been explicitly renamed to get_surf_session_detail and continues to use
         get_session_detail (formerly get_session) to return the full session object, ensuring no change in its behavior.

   4. Consistent API Response Formatting:
       * The _format_session_response helper function in database_utils.py has been refined to ensure all timestamp fields are consistently
         formatted as ISO 8601 UTC strings.
       * The tide object is now completely omitted from the lightweight responses if it contains no data, further reducing payload size.

   5. Impact on Session Creation/Update:
       * The create_session and update_session functions now return the consistently formatted session object, ensuring a clean response even for
         the MVP.

  Acceptance Criteria Addressed:

   * The main feed and journal views now return lightweight JSON payloads, significantly improving load times.
   * Both feed and journal views support robust server-side filtering by swell height, period, and direction.
   * The session detail view continues to provide complete oceanographic data.
   * Clear separation of concerns between detail and summary list functions is established.

  This change lays the groundwork for a more performant and scalable application.
