### PR TITLE
Create session

### DIFF
--- a/CREATE_SESSION_PLAN.md
+++ b/CREATE_SESSION_PLAN.md
@@ -1,0 +1,95 @@
+### **Implementation Plan: Create Session Page**
+
+This plan outlines the steps to create a new, fully functional `CreateSessionPage.jsx` component that integrates with the backend to log new surf sessions.
+
+---
+
+### **Phase 1: Page Scaffolding & Static Form Layout**
+
+**Goal:** Create the basic structure of the page and add the form UI. This will make the page visible and routable in the app immediately.
+
+1.  **Create New File**: Create `frontend/src/pages/CreateSessionPage.jsx`.
+2.  **Add Route**: In your main router file (likely `App.jsx` or a dedicated router config), add a new protected route for `/create-session` that renders `CreateSessionPage`. The existing bottom navigation should now link to this page correctly.
+3.  **Build Static UI**:
+    *   Inside `CreateSessionPage.jsx`, lay out the main form structure.
+    *   Use the reusable `Input`, `Button`, and `Card` components from `frontend/src/components/UI/` to create fields for:
+        *   Date (type="date")
+        *   Location (placeholder `<select>` dropdown)
+        *   Title (text input)
+        *   Start Time (type="time")
+        *   End Time (type="time")
+        *   Fun Rating (e.g., a number input or a simple select 1-5)
+        *   Notes (textarea)
+        *   A placeholder button for "Tag Surfers".
+    *   Add a "Save Session" button.
+
+**Outcome:** You will be able to navigate to a `/create-session` page and see the complete, un-styled form layout.
+
+---
+
+### **Phase 2: Location Data Integration**
+
+**Goal:** Make the location dropdown dynamic by fetching and displaying real surf spots from the backend.
+
+1.  **State Management**: In `CreateSessionPage.jsx`, use `useState` to manage the list of locations and the selected location.
+2.  **API Call**: Use a `useEffect` hook to call the `GET /api/surf-spots-by-region` endpoint when the component mounts. Use the centralized `apiCall` service for this.
+3.  **Populate Dropdown**:
+    *   Render the fetched data in the `<select>` element.
+    *   Use `<optgroup>` to group the spots by their `region`.
+    *   For each `<option>`, set its `value` to the spot's `slug` and display the spot's `name`. This is critical for the backend.
+
+**Outcome:** The location dropdown will be populated with correctly grouped surf spots, and selecting one will update the component's state.
+
+---
+
+### **Phase 3: User Search & Tagging**
+
+**Goal:** Integrate the user search functionality to allow tagging other surfers in the session.
+
+1.  **State Management**: Create a `useState` variable (e.g., `taggedUsers`) to hold an array of selected user objects.
+2.  **Integrate `UserSearch` Component**:
+    *   The "Tag Surfers" button should open the `UserSearch.jsx` modal.
+    *   Pass a callback function to the `UserSearch` component that adds a selected user to the `taggedUsers` array.
+3.  **Display Tagged Users**: Render the `display_name` of each user in the `taggedUsers` array below the "Tag Surfers" button. Add a small "x" button next to each name to allow for their removal from the array.
+
+**Outcome:** You will be able to click "Tag Surfers," search for users by name, add them to the session, and see them listed on the form.
+
+---
+
+### **Phase 4: Form Submission & Full API Integration**
+
+**Goal:** Make the form fully functional by handling submission, sending the data to the backend, and managing the response.
+
+1.  **Form State**: Ensure all form inputs are controlled components, with their values tied to `useState` variables.
+2.  **Submit Handler**: Create an `async` function `handleSubmit` that is triggered by the "Save Session" button.
+3.  **Construct Payload**: Inside `handleSubmit`, assemble the form data into a JSON object that matches the payload expected by the `POST /api/surf-sessions` endpoint.
+    *   `date`: `YYYY-MM-DD` string.
+    *   `time`: `HH:MM` string.
+    *   `end_time`: `HH:MM` string.
+    *   `location`: The selected location `slug` (not the name).
+    *   `session_name`: The title string.
+    *   `fun_rating`: The rating number.
+    *   `session_notes`: The notes string.
+    *   `tagged_users`: An array of user **IDs** (e.g., `['uuid-1', 'uuid-2']`), extracted from your `taggedUsers` state array.
+4.  **API Call**: Use the `apiCall` service to send the `POST` request.
+5.  **Handle Response**:
+    *   **On Success**: Use `react-hot-toast` to show a success message. Redirect the user to their journal (`/journal`) or the new session's detail page. The API response should contain the new session's ID, which you'll need for the redirect (`/session/<new_id>`).
+    *   **On Error**: Use `react-hot-toast` to display a user-friendly error message from the API response.
+
+**Outcome:** The form will be fully operational. You can fill it out, tag users, and successfully create a new session that is saved to the database.
+
+---
+
+### **Phase 5: Final Polish & Validation**
+
+**Goal:** Improve the user experience with loading indicators and basic client-side validation.
+
+1.  **Loading States**:
+    *   Display a `Spinner` while the locations are being fetched.
+    *   Disable the "Save Session" button and show a spinner or "Saving..." text while the form is submitting.
+2.  **Client-Side Validation**:
+    *   Add `required` attributes to essential form fields.
+    *   Implement a check to ensure `end_time` is after `start_time`.
+    *   Provide clear error messages if validation fails before submitting.
+
+**Outcome:** The page will feel robust, providing clear feedback to the user during asynchronous operations and preventing invalid data submission.

--- a/CREATE_SESSION_PLAN.md
+++ b/CREATE_SESSION_PLAN.md
@@ -1,58 +1,42 @@
-### **Implementation Plan: Create Session Page**
+### **Implementation Plan: Create Session Page (Revised)**
 
-This plan outlines the steps to create a new, fully functional `CreateSessionPage.jsx` component that integrates with the backend to log new surf sessions.
-
----
-
-### **Phase 1: Page Scaffolding & Static Form Layout**
-
-**Goal:** Create the basic structure of the page and add the form UI. This will make the page visible and routable in the app immediately.
-
-1.  **Create New File**: Create `frontend/src/pages/CreateSessionPage.jsx`.
-2.  **Add Route**: In your main router file (likely `App.jsx` or a dedicated router config), add a new protected route for `/create-session` that renders `CreateSessionPage`. The existing bottom navigation should now link to this page correctly.
-3.  **Build Static UI**:
-    *   Inside `CreateSessionPage.jsx`, lay out the main form structure.
-    *   Use the reusable `Input`, `Button`, and `Card` components from `frontend/src/components/UI/` to create fields for:
-        *   Date (type="date")
-        *   Location (placeholder `<select>` dropdown)
-        *   Title (text input)
-        *   Start Time (type="time")
-        *   End Time (type="time")
-        *   Fun Rating (e.g., a number input or a simple select 1-5)
-        *   Notes (textarea)
-        *   A placeholder button for "Tag Surfers".
-    *   Add a "Save Session" button.
-
-**Outcome:** You will be able to navigate to a `/create-session` page and see the complete, un-styled form layout.
+This plan outlines the steps to create a new, fully functional `CreateSessionPage.jsx` component. The original plan to use a modal for user search has been revised in favor of a more streamlined, inline search experience.
 
 ---
 
-### **Phase 2: Location Data Integration**
+### **Phase 1: Page Scaffolding & Static Form Layout (Complete)**
+
+**Goal:** Create the basic structure of the page and add the form UI.
+
+*This phase is complete.*
+
+---
+
+### **Phase 2: Location Data Integration (Complete)**
 
 **Goal:** Make the location dropdown dynamic by fetching and displaying real surf spots from the backend.
 
-1.  **State Management**: In `CreateSessionPage.jsx`, use `useState` to manage the list of locations and the selected location.
-2.  **API Call**: Use a `useEffect` hook to call the `GET /api/surf-spots-by-region` endpoint when the component mounts. Use the centralized `apiCall` service for this.
-3.  **Populate Dropdown**:
-    *   Render the fetched data in the `<select>` element.
-    *   Use `<optgroup>` to group the spots by their `region`.
-    *   For each `<option>`, set its `value` to the spot's `slug` and display the spot's `name`. This is critical for the backend.
-
-**Outcome:** The location dropdown will be populated with correctly grouped surf spots, and selecting one will update the component's state.
+*This phase is complete.*
 
 ---
 
-### **Phase 3: User Search & Tagging**
+### **Revised Phase 3: Inline User Search & Tagging**
 
-**Goal:** Integrate the user search functionality to allow tagging other surfers in the session.
+**Goal:** Replace the modal with a seamless, inline user search and tagging experience to improve UX and resolve a rendering bug.
 
-1.  **State Management**: Create a `useState` variable (e.g., `taggedUsers`) to hold an array of selected user objects.
-2.  **Integrate `UserSearch` Component**:
-    *   The "Tag Surfers" button should open the `UserSearch.jsx` modal.
-    *   Pass a callback function to the `UserSearch` component that adds a selected user to the `taggedUsers` array.
-3.  **Display Tagged Users**: Render the `display_name` of each user in the `taggedUsers` array below the "Tag Surfers" button. Add a small "x" button next to each name to allow for their removal from the array.
-
-**Outcome:** You will be able to click "Tag Surfers," search for users by name, add them to the session, and see them listed on the form.
+1.  **Remove Modal Logic**: In `CreateSessionPage.jsx`, remove the `isUserSearchOpen` state, the "Search & Tag Friends" button, and the conditional rendering for the `<UserSearch />` component.
+2.  **Add Inline Search UI**:
+    *   Add a new `Input` field to the form with the label "Tag Surfers".
+    *   Add new state variables to manage the search query text and the list of search results.
+3.  **Implement Live Search**:
+    *   As the user types into the new search input, a `useEffect` hook will trigger a debounced call to the `/api/users/search` endpoint.
+    *   The returned user list will be stored in the search results state.
+4.  **Display Results Dropdown**:
+    *   A dropdown list will appear directly below the search input, showing the names of matching users.
+    *   Each name in the list will be a clickable button.
+5.  **Implement User Selection**:
+    *   Clicking a user from the results list will add them to the `taggedUsers` array and clear the search input and results list.
+    *   The selected users will be displayed as dismissible tags on the form.
 
 ---
 
@@ -62,21 +46,11 @@ This plan outlines the steps to create a new, fully functional `CreateSessionPag
 
 1.  **Form State**: Ensure all form inputs are controlled components, with their values tied to `useState` variables.
 2.  **Submit Handler**: Create an `async` function `handleSubmit` that is triggered by the "Save Session" button.
-3.  **Construct Payload**: Inside `handleSubmit`, assemble the form data into a JSON object that matches the payload expected by the `POST /api/surf-sessions` endpoint.
-    *   `date`: `YYYY-MM-DD` string.
-    *   `time`: `HH:MM` string.
-    *   `end_time`: `HH:MM` string.
-    *   `location`: The selected location `slug` (not the name).
-    *   `session_name`: The title string.
-    *   `fun_rating`: The rating number.
-    *   `session_notes`: The notes string.
-    *   `tagged_users`: An array of user **IDs** (e.g., `['uuid-1', 'uuid-2']`), extracted from your `taggedUsers` state array.
+3.  **Construct Payload**: Inside `handleSubmit`, assemble the form data into a JSON object that matches the payload expected by the `POST /api/surf-sessions` endpoint. This includes the array of `tagged_users` IDs.
 4.  **API Call**: Use the `apiCall` service to send the `POST` request.
 5.  **Handle Response**:
-    *   **On Success**: Use `react-hot-toast` to show a success message. Redirect the user to their journal (`/journal`) or the new session's detail page. The API response should contain the new session's ID, which you'll need for the redirect (`/session/<new_id>`).
-    *   **On Error**: Use `react-hot-toast` to display a user-friendly error message from the API response.
-
-**Outcome:** The form will be fully operational. You can fill it out, tag users, and successfully create a new session that is saved to the database.
+    *   **On Success**: Use `react-hot-toast` to show a success message and redirect the user.
+    *   **On Error**: Use `react-hot-toast` to display a user-friendly error message.
 
 ---
 
@@ -84,12 +58,5 @@ This plan outlines the steps to create a new, fully functional `CreateSessionPag
 
 **Goal:** Improve the user experience with loading indicators and basic client-side validation.
 
-1.  **Loading States**:
-    *   Display a `Spinner` while the locations are being fetched.
-    *   Disable the "Save Session" button and show a spinner or "Saving..." text while the form is submitting.
-2.  **Client-Side Validation**:
-    *   Add `required` attributes to essential form fields.
-    *   Implement a check to ensure `end_time` is after `start_time`.
-    *   Provide clear error messages if validation fails before submitting.
-
-**Outcome:** The page will feel robust, providing clear feedback to the user during asynchronous operations and preventing invalid data submission.
+1.  **Loading States**: Add `Spinner` components for any asynchronous operations.
+2.  **Client-Side Validation**: Add `required` attributes and other simple checks to prevent invalid form submission.

--- a/frontend/src/components/UserSearch.jsx
+++ b/frontend/src/components/UserSearch.jsx
@@ -62,13 +62,25 @@ const UserSearch = ({ onClose }) => {
           <ul>
             {!loading && !error && results.map(user => (
               <li key={user.user_id} className="border-b">
-                <Link
-                  to={`/journal/${user.user_id}`}
-                  onClick={onClose} // Close modal on selection
-                  className="block p-2 hover:bg-gray-100"
-                >
-                  {user.display_name || user.email}
-                </Link>
+                {onSelectUser ? (
+                    <button
+                      onClick={() => {
+                        onSelectUser(user);
+                        onClose(); // Optionally close modal on selection
+                      }}
+                      className="block w-full text-left p-2 hover:bg-gray-100"
+                    >
+                      {user.display_name || user.email}
+                    </button>
+                  ) : (
+                    <Link
+                      to={`/journal/${user.user_id}`}
+                      onClick={onClose} // Close modal on navigation
+                      className="block p-2 hover:bg-gray-100"
+                    >
+                      {user.display_name || user.email}
+                    </Link>
+                  )}
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/CreateSessionPage.jsx
+++ b/frontend/src/pages/CreateSessionPage.jsx
@@ -110,7 +110,7 @@ function CreateSessionPage() {
         session_name: sessionName,
         time: startTime,
         end_time: endTime,
-        fun_rating: parseInt(funRating, 10),
+        fun_rating: parseFloat(funRating), // Changed from parseInt to parseFloat
         session_notes: notes,
         tagged_users: taggedUsers.map(user => user.user_id) // Send only user IDs
       };
@@ -187,8 +187,8 @@ function CreateSessionPage() {
           </div>
 
           <div>
-            <label htmlFor="fun_rating" className="block text-sm font-medium text-gray-300">Fun Rating (1-5)</label>
-            <Input type="number" id="fun_rating" name="fun_rating" min="1" max="5" value={funRating} onChange={(e) => setFunRating(e.target.value)} />
+            <label htmlFor="fun_rating" className="block text-sm font-medium text-gray-300">Fun Rating (1-10, 2 decimal places)</label>
+            <Input type="number" id="fun_rating" name="fun_rating" min="1" max="10" step="0.01" value={funRating} onChange={(e) => setFunRating(e.target.value)} />
           </div>
 
           <div>

--- a/frontend/src/pages/CreateSessionPage.jsx
+++ b/frontend/src/pages/CreateSessionPage.jsx
@@ -1,12 +1,100 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { apiCall } from '../services/api';
+import Card from '../components/UI/Card';
+import Input from '../components/UI/Input';
+import Button from '../components/UI/Button';
 
-const CreateSessionPage = () => {
+function CreateSessionPage() {
+  const [locations, setLocations] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchLocations = async () => {
+      try {
+        const response = await apiCall('/api/surf-spots-by-region');
+        setLocations(response.data || []);
+      } catch (error) {
+        console.error("Failed to fetch locations:", error);
+        // Optionally, set an error state and display a message to the user
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLocations();
+  }, []);
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-      <h2 className="text-3xl font-bold text-gray-800">Create Session Form</h2>
-      <p className="mt-2 text-gray-600">This is a placeholder page for creating a new surf session.</p>
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold text-center mb-6">Create New Surf Session</h1>
+      <Card>
+        <form className="space-y-4">
+          <div>
+            <label htmlFor="date" className="block text-sm font-medium text-gray-300">Date</label>
+            <Input type="date" id="date" name="date" />
+          </div>
+
+          <div>
+            <label htmlFor="location" className="block text-sm font-medium text-gray-300">Location</label>
+            <select id="location" name="location" className="mt-1 block w-full bg-gray-700 border-gray-600 text-white rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm p-2">
+              {isLoading ? (
+                <option>Loading locations...</option>
+              ) : (
+                <>
+                  <option value="">Select a spot</option>
+                  {locations.map(region => (
+                    <optgroup key={region.region} label={region.region}>
+                      {region.spots.map(spot => (
+                        <option key={spot.slug} value={spot.slug}>
+                          {spot.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </>
+              )}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="title" className="block text-sm font-medium text-gray-300">Title</label>
+            <Input type="text" id="title" name="title" placeholder="e.g., Fun morning session" />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="start_time" className="block text-sm font-medium text-gray-300">Start Time</label>
+              <Input type="time" id="start_time" name="start_time" />
+            </div>
+            <div>
+              <label htmlFor="end_time" className="block text-sm font-medium text-gray-300">End Time</label>
+              <Input type="time" id="end_time" name="end_time" />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="fun_rating" className="block text-sm font-medium text-gray-300">Fun Rating (1-5)</label>
+            <Input type="number" id="fun_rating" name="fun_rating" min="1" max="5" />
+          </div>
+
+          <div>
+            <label htmlFor="notes" className="block text-sm font-medium text-gray-300">Notes</label>
+            <textarea id="notes" name="notes" rows="4" className="mt-1 block w-full bg-gray-700 border-gray-600 text-white rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm p-2" placeholder="How were the waves?"></textarea>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300">Tag Surfers</label>
+            <Button type="button" className="mt-1">Search & Tag Friends</Button>
+            {/* Tagged users will be displayed here */}
+          </div>
+
+          <div className="pt-4">
+            <Button type="submit" className="w-full">Save Session</Button>
+          </div>
+        </form>
+      </Card>
     </div>
   );
-};
+}
 
 export default CreateSessionPage;


### PR DESCRIPTION
Added in the fully functional create session page. It's pretty ugly but functional. Also check out locations -- pretty sweet. 


✦ feat: Implement Create Session Page with Inline User Tagging
 
This pull request introduces the new "Create Session" page, allowing users to log their surf sessions with comprehensive details and tag other surfers.
 
Key features implemented:
    - **Session Details Form**: A user-friendly form to input session date, location, title, start/end times, fun rating, and notes.
    - **Dynamic Location Selection**: The location dropdown is now populated dynamically from the backend, displaying surf spot names
      while sending their corresponding slugs to the API.
    - **Inline User Tagging**: Replaced the previous modal-based user search with a more intuitive inline search bar. Users can now
      search for and tag friends directly within the form, with selected users displayed as dismissible tags. This revision also addressed
      a rendering bug encountered with the modal approach, improving overall UX.
    - **API Integration**: The form fully integrates with the `/api/surf-sessions` endpoint for creating new sessions, including handling
      tagged participants.
   - **User Feedback**: Implemented loading states for data fetching, user search, and form submission, along with toast notifications
      for success and error messages.
   - **Enhanced Fun Rating**: The "Fun Rating" input now supports a range of 1-10 with up to two decimal places, providing more granular
      feedback.
 
This implementation follows the detailed plan outlined in `CREATE_SESSION_PLAN.md`.