### PR TITLE
Journal page

### DIFF
--- a/JOURNAL_PAGE_PLAN.md
+++ b/JOURNAL_PAGE_PLAN.md
@@ -4,32 +4,32 @@ This revised plan breaks down the Journal Page implementation into smaller, test
 
 ---
 
-**Phase 1: Backend API Foundation (Re-establish & Verify)**
+**Phase 1: Backend API Foundation (Re-establish & Verify) ✅**
 *   **Goal:** Ensure all necessary backend API endpoints are fully functional and accessible from the frontend, both locally and on Vercel.
 *   **Piecemeal Steps:**
 
-    1.  **Re-implement `get_user_profile_by_id` in `database_utils.py` (if reverted).**
+    1.  **Re-implement `get_user_profile_by_id` in `database_utils.py` (if reverted). ✅**
         *   **Action:** Add or confirm the `get_user_profile_by_id` function in `database_utils.py`.
         *   **Test:** Run a Python interpreter or a local Flask shell and call `database_utils.get_user_profile_by_id('a_valid_user_id')`. Confirm it returns the expected user profile data.
 
-    2.  **Re-implement `/api/users/<user_id>/profile` endpoint in `surfdata.py` with `GET` and `OPTIONS` methods.**
+    2.  **Re-implement `/api/users/<user_id>/profile` endpoint in `surfdata.py` with `GET` and `OPTIONS` methods. ✅**
         *   **Action:** Add or confirm the `@app.route('/api/users/<string:user_id>/profile', methods=['GET', 'OPTIONS'])` decorator and its associated function in `surfdata.py`.
         *   **Test:**
             *   **Local:** Start your Flask backend (`python surfdata.py`). Use Postman (or `curl`) to send `GET` and `OPTIONS` requests to `http://localhost:5000/api/users/<your_user_id>/profile` (using a valid JWT in the `Authorization` header). Confirm both return `200 OK` and the `GET` request returns the correct profile data.
             *   **Vercel:** Deploy these changes to Vercel. Use Postman to send `GET` and `OPTIONS` requests to your Vercel backend URL (e.g., `https://your-backend.vercel.app/api/users/<your_user_id>/profile`). Confirm both return `200 OK` and the `GET` request returns the correct profile data.
 
-    3.  **Re-implement global `OPTIONS` handler in `surfdata.py` (if reverted).**
+    3.  **Re-implement global `OPTIONS` handler in `surfdata.py` (if reverted). ✅**
         *   **Action:** Add or confirm the `@app.before_request` global `OPTIONS` handler in `surfdata.py`.
         *   **Test:**
             *   **Local:** Start your Flask backend. Use Postman to send an `OPTIONS` request to *any* endpoint (e.g., `http://localhost:5000/api/auth/login`). Confirm `200 OK`.
             *   **Vercel:** Deploy these changes to Vercel. Use Postman to send an `OPTIONS` request to *any* endpoint on your Vercel backend URL. Confirm `200 OK`.
 
-    4.  **Re-implement `vercel.json` rewrite rules.**
+    4.  **Re-implement `vercel.json` rewrite rules. ✅**
         *   **Action:** Add or confirm the rewrite rules in `vercel.json` that prepend `/api/` to incoming requests (e.g., `src: "/(.*)", dest: "/api/$1"`).
         *   **Test:**
             *   **Vercel:** Deploy these changes to Vercel. Use Postman to send a `GET` request to `https://your-backend.vercel.app/users/<your_user_id>/profile` (note: *without* `/api/` in the URL). Confirm it returns `200 OK` and the correct profile data. This verifies the rewrite rule.
 
-    5.  **Verify `get_user_journal_sessions` endpoint in `surfdata.py` (already exists).**
+    5.  **Verify `get_user_journal_sessions` endpoint in `surfdata.py` (already exists). ✅**
         *   **Action:** Confirm the `get_user_journal_sessions` endpoint is present and correctly calls `database_utils.get_user_sessions`.
         *   **Test:**
             *   **Local:** Start your Flask backend. Use Postman to send a `GET` request to `http://localhost:5000/api/users/<your_user_id>/sessions`. Confirm `200 OK` and that it returns sessions for the specified user.
@@ -41,11 +41,11 @@ This revised plan breaks down the Journal Page implementation into smaller, test
 *   **Goal:** Get the Journal page to display the user's name and a list of sessions.
 *   **Piecemeal Steps:**
 
-    1.  **Create `JournalPage.jsx` (basic structure).**
+    1.  **Create `JournalPage.jsx` (basic structure). ✅**
         *   **Action:** Create `frontend/src/pages/JournalPage.jsx` with the initial `useState`, `useEffect`, and basic JSX structure (as previously discussed, but without the `PageTabs` for now).
         *   **Test:** Run your frontend dev server (`npm run dev`). Navigate to `http://localhost:5173/journal/me` (or any valid user ID). Confirm the page loads with a placeholder title.
 
-    2.  **Implement routing in `App.jsx` for `/journal/:userId` and redirect `/journal` to `/journal/me`.**
+    2.  **Implement routing in `App.jsx` for `/journal/:userId` and redirect `/journal` to `/journal/me`. ✅**
         *   **Action:** Modify `frontend/src/App.jsx` to include the route for `/journal/:userId` and the redirect from `/journal` to `/journal/me`.
         *   **Test:** Navigate to `http://localhost:5173/journal` (should redirect to `/journal/me`). Navigate to `http://localhost:5173/journal/some-valid-user-id`. Confirm correct routing.
 

--- a/JOURNAL_PAGE_PLAN.md
+++ b/JOURNAL_PAGE_PLAN.md
@@ -53,9 +53,13 @@ This revised plan breaks down the Journal Page implementation into smaller, test
         *   **Action:** In `JournalPage.jsx`, implement the `useEffect` to call the `/users/:userId/profile` endpoint and update the `profileUser` state. Display `profileUser.display_name` in the `<h1>` tag.
         *   **Test:** Navigate to the Journal page. Confirm the correct user's display name appears at the top of the page. Check console for any errors.
 
-    4.  **Fetch and display sessions using `SessionsList` in `JournalPage.jsx`.**
+    4.  **Fetch and display sessions using `SessionsList` in `JournalPage.jsx`. ✅**
         *   **Action:** In `JournalPage.jsx`, implement the `useEffect` to call the `/users/:userId/sessions` endpoint and update the `sessions` state. Integrate the `SessionsList` component, passing `sessions`, `loading`, and `error` props.
         *   **Test:** Navigate to the Journal page. Confirm sessions load and display correctly. Verify loading and error states are handled.
+
+    5.  **Implement Journal Page Tabs (Log / My Stats).**
+        *   **Action:** Integrate `PageTabs.jsx` into `JournalPage.jsx`. Define "Log" and "My Stats" tabs, dynamically linking paths to the `userId`. Implement conditional rendering based on URL `tab` query parameter.
+        *   **Test:** Navigate to the Journal page. Verify tabs are visible and clickable. Confirm switching tabs changes content (Log shows sessions, My Stats shows placeholder).
 
 ---
 

--- a/JOURNAL_PAGE_PLAN.md
+++ b/JOURNAL_PAGE_PLAN.md
@@ -1,0 +1,43 @@
+# Journal Page Implementation Plan
+
+This document outlines the phased implementation plan for the Journal Page feature, focusing on displaying surf sessions and implementing filtering capabilities. The "Stats" tab functionality is explicitly excluded from this phase.
+
+## Phase 1: Backend Enhancement - New User Profile Endpoint
+
+*   **Goal:** Create a dedicated API endpoint to fetch a user's display name and basic profile information, ensuring the display name is always available regardless of session count.
+*   **Steps:**
+    1.  **`database_utils.py`:** Add a new function, `get_user_profile_by_id(user_id)`, to query the `auth.users` table and return the `id`, `email`, and `display_name` for the given `user_id`.
+    2.  **`surfdata.py`:** Add a new `GET` endpoint, `/api/users/<string:user_id>/profile`, which will call the new `database_utils` function. This endpoint must be protected by `@token_required`.
+
+## Phase 2: Page Scaffolding and Routing
+
+*   **Goal:** Create the basic `JournalPage` component and integrate it into the app's navigation.
+*   **Steps:**
+    1.  Create `frontend/src/pages/JournalPage.jsx`.
+    2.  Set up the component to read the `userId` from the URL (`/journal/:userId`). It will handle the `'me'` alias to refer to the currently authenticated user.
+    3.  Add the new route `/journal/:userId` to `App.jsx` within the `ProtectedRoute`.
+
+## Phase 3: User Profile and Session Data Fetching
+
+*   **Goal:** Fetch and display the user's display name and their surf sessions.
+*   **Steps:**
+    1.  In `JournalPage.jsx`, use the new `/api/users/:userId/profile` endpoint to fetch the `display_name` of the user whose journal is being viewed. Display this name prominently at the top of the page.
+    2.  Fetch session data from the existing `/api/users/:userId/sessions` endpoint.
+    3.  Use the existing `SessionsList.jsx` component to display the fetched sessions, handling loading, error, and empty states.
+
+## Phase 4: Minimalist Filter UI Implementation
+
+*   **Goal:** Implement the toggleable filter section.
+*   **Steps:**
+    1.  Create `frontend/src/components/JournalFilter.jsx`. This component will contain all the individual filter controls (Region, Swell Height, Swell Period, Swell Direction).
+    2.  Implement a toggle mechanism within `JournalFilter.jsx` (e.g., a button that expands/collapses a div) to reveal or hide the filter options.
+    3.  Add `JournalFilter.jsx` to `JournalPage.jsx`.
+
+## Phase 5: Filter Logic and API Integration
+
+*   **Goal:** Make the filters functional by connecting them to the API and updating the view.
+*   **Steps:**
+    1.  Fetch the list of available regions from the `/api/regions` endpoint and populate the "Region" filter dropdown in `JournalFilter.jsx`.
+    2.  Implement state management in `JournalPage.jsx` to hold the current filter values.
+    3.  When a filter value changes, update the state and re-fetch the session data from the backend, passing the filter values as query parameters to `/api/users/:userId/sessions`.
+    4.  Update the URL with the current filter parameters using `react-router-dom`'s `useSearchParams` hook.

--- a/JOURNAL_PAGE_PLAN.md
+++ b/JOURNAL_PAGE_PLAN.md
@@ -49,7 +49,7 @@ This revised plan breaks down the Journal Page implementation into smaller, test
         *   **Action:** Modify `frontend/src/App.jsx` to include the route for `/journal/:userId` and the redirect from `/journal` to `/journal/me`.
         *   **Test:** Navigate to `http://localhost:5173/journal` (should redirect to `/journal/me`). Navigate to `http://localhost:5173/journal/some-valid-user-id`. Confirm correct routing.
 
-    3.  **Fetch and display user's `display_name` in `JournalPage.jsx`.**
+    3.  **Fetch and display user's `display_name` in `JournalPage.jsx`. ✅**
         *   **Action:** In `JournalPage.jsx`, implement the `useEffect` to call the `/users/:userId/profile` endpoint and update the `profileUser` state. Display `profileUser.display_name` in the `<h1>` tag.
         *   **Test:** Navigate to the Journal page. Confirm the correct user's display name appears at the top of the page. Check console for any errors.
 

--- a/JOURNAL_PAGE_PLAN.md
+++ b/JOURNAL_PAGE_PLAN.md
@@ -1,43 +1,94 @@
-# Journal Page Implementation Plan
+### Revised Journal Page Implementation Plan (Piecemeal)
 
-This document outlines the phased implementation plan for the Journal Page feature, focusing on displaying surf sessions and implementing filtering capabilities. The "Stats" tab functionality is explicitly excluded from this phase.
+This revised plan breaks down the Journal Page implementation into smaller, testable steps, allowing for incremental verification and quicker issue identification.
 
-## Phase 1: Backend Enhancement - New User Profile Endpoint
+---
 
-*   **Goal:** Create a dedicated API endpoint to fetch a user's display name and basic profile information, ensuring the display name is always available regardless of session count.
-*   **Steps:**
-    1.  **`database_utils.py`:** Add a new function, `get_user_profile_by_id(user_id)`, to query the `auth.users` table and return the `id`, `email`, and `display_name` for the given `user_id`.
-    2.  **`surfdata.py`:** Add a new `GET` endpoint, `/api/users/<string:user_id>/profile`, which will call the new `database_utils` function. This endpoint must be protected by `@token_required`.
+**Phase 1: Backend API Foundation (Re-establish & Verify)**
+*   **Goal:** Ensure all necessary backend API endpoints are fully functional and accessible from the frontend, both locally and on Vercel.
+*   **Piecemeal Steps:**
 
-## Phase 2: Page Scaffolding and Routing
+    1.  **Re-implement `get_user_profile_by_id` in `database_utils.py` (if reverted).**
+        *   **Action:** Add or confirm the `get_user_profile_by_id` function in `database_utils.py`.
+        *   **Test:** Run a Python interpreter or a local Flask shell and call `database_utils.get_user_profile_by_id('a_valid_user_id')`. Confirm it returns the expected user profile data.
 
-*   **Goal:** Create the basic `JournalPage` component and integrate it into the app's navigation.
-*   **Steps:**
-    1.  Create `frontend/src/pages/JournalPage.jsx`.
-    2.  Set up the component to read the `userId` from the URL (`/journal/:userId`). It will handle the `'me'` alias to refer to the currently authenticated user.
-    3.  Add the new route `/journal/:userId` to `App.jsx` within the `ProtectedRoute`.
+    2.  **Re-implement `/api/users/<user_id>/profile` endpoint in `surfdata.py` with `GET` and `OPTIONS` methods.**
+        *   **Action:** Add or confirm the `@app.route('/api/users/<string:user_id>/profile', methods=['GET', 'OPTIONS'])` decorator and its associated function in `surfdata.py`.
+        *   **Test:**
+            *   **Local:** Start your Flask backend (`python surfdata.py`). Use Postman (or `curl`) to send `GET` and `OPTIONS` requests to `http://localhost:5000/api/users/<your_user_id>/profile` (using a valid JWT in the `Authorization` header). Confirm both return `200 OK` and the `GET` request returns the correct profile data.
+            *   **Vercel:** Deploy these changes to Vercel. Use Postman to send `GET` and `OPTIONS` requests to your Vercel backend URL (e.g., `https://your-backend.vercel.app/api/users/<your_user_id>/profile`). Confirm both return `200 OK` and the `GET` request returns the correct profile data.
 
-## Phase 3: User Profile and Session Data Fetching
+    3.  **Re-implement global `OPTIONS` handler in `surfdata.py` (if reverted).**
+        *   **Action:** Add or confirm the `@app.before_request` global `OPTIONS` handler in `surfdata.py`.
+        *   **Test:**
+            *   **Local:** Start your Flask backend. Use Postman to send an `OPTIONS` request to *any* endpoint (e.g., `http://localhost:5000/api/auth/login`). Confirm `200 OK`.
+            *   **Vercel:** Deploy these changes to Vercel. Use Postman to send an `OPTIONS` request to *any* endpoint on your Vercel backend URL. Confirm `200 OK`.
 
-*   **Goal:** Fetch and display the user's display name and their surf sessions.
-*   **Steps:**
-    1.  In `JournalPage.jsx`, use the new `/api/users/:userId/profile` endpoint to fetch the `display_name` of the user whose journal is being viewed. Display this name prominently at the top of the page.
-    2.  Fetch session data from the existing `/api/users/:userId/sessions` endpoint.
-    3.  Use the existing `SessionsList.jsx` component to display the fetched sessions, handling loading, error, and empty states.
+    4.  **Re-implement `vercel.json` rewrite rules.**
+        *   **Action:** Add or confirm the rewrite rules in `vercel.json` that prepend `/api/` to incoming requests (e.g., `src: "/(.*)", dest: "/api/$1"`).
+        *   **Test:**
+            *   **Vercel:** Deploy these changes to Vercel. Use Postman to send a `GET` request to `https://your-backend.vercel.app/users/<your_user_id>/profile` (note: *without* `/api/` in the URL). Confirm it returns `200 OK` and the correct profile data. This verifies the rewrite rule.
 
-## Phase 4: Minimalist Filter UI Implementation
+    5.  **Verify `get_user_journal_sessions` endpoint in `surfdata.py` (already exists).**
+        *   **Action:** Confirm the `get_user_journal_sessions` endpoint is present and correctly calls `database_utils.get_user_sessions`.
+        *   **Test:**
+            *   **Local:** Start your Flask backend. Use Postman to send a `GET` request to `http://localhost:5000/api/users/<your_user_id>/sessions`. Confirm `200 OK` and that it returns sessions for the specified user.
+            *   **Vercel:** Deploy these changes to Vercel. Use Postman to send a `GET` request to `https://your-backend.vercel.app/api/users/<your_user_id>/sessions`. Confirm `200 OK` and correct data.
 
-*   **Goal:** Implement the toggleable filter section.
-*   **Steps:**
-    1.  Create `frontend/src/components/JournalFilter.jsx`. This component will contain all the individual filter controls (Region, Swell Height, Swell Period, Swell Direction).
-    2.  Implement a toggle mechanism within `JournalFilter.jsx` (e.g., a button that expands/collapses a div) to reveal or hide the filter options.
-    3.  Add `JournalFilter.jsx` to `JournalPage.jsx`.
+---
 
-## Phase 5: Filter Logic and API Integration
+**Phase 2: Frontend Journal Page - Basic Display**
+*   **Goal:** Get the Journal page to display the user's name and a list of sessions.
+*   **Piecemeal Steps:**
 
-*   **Goal:** Make the filters functional by connecting them to the API and updating the view.
-*   **Steps:**
-    1.  Fetch the list of available regions from the `/api/regions` endpoint and populate the "Region" filter dropdown in `JournalFilter.jsx`.
-    2.  Implement state management in `JournalPage.jsx` to hold the current filter values.
-    3.  When a filter value changes, update the state and re-fetch the session data from the backend, passing the filter values as query parameters to `/api/users/:userId/sessions`.
-    4.  Update the URL with the current filter parameters using `react-router-dom`'s `useSearchParams` hook.
+    1.  **Create `JournalPage.jsx` (basic structure).**
+        *   **Action:** Create `frontend/src/pages/JournalPage.jsx` with the initial `useState`, `useEffect`, and basic JSX structure (as previously discussed, but without the `PageTabs` for now).
+        *   **Test:** Run your frontend dev server (`npm run dev`). Navigate to `http://localhost:5173/journal/me` (or any valid user ID). Confirm the page loads with a placeholder title.
+
+    2.  **Implement routing in `App.jsx` for `/journal/:userId` and redirect `/journal` to `/journal/me`.**
+        *   **Action:** Modify `frontend/src/App.jsx` to include the route for `/journal/:userId` and the redirect from `/journal` to `/journal/me`.
+        *   **Test:** Navigate to `http://localhost:5173/journal` (should redirect to `/journal/me`). Navigate to `http://localhost:5173/journal/some-valid-user-id`. Confirm correct routing.
+
+    3.  **Fetch and display user's `display_name` in `JournalPage.jsx`.**
+        *   **Action:** In `JournalPage.jsx`, implement the `useEffect` to call the `/users/:userId/profile` endpoint and update the `profileUser` state. Display `profileUser.display_name` in the `<h1>` tag.
+        *   **Test:** Navigate to the Journal page. Confirm the correct user's display name appears at the top of the page. Check console for any errors.
+
+    4.  **Fetch and display sessions using `SessionsList` in `JournalPage.jsx`.**
+        *   **Action:** In `JournalPage.jsx`, implement the `useEffect` to call the `/users/:userId/sessions` endpoint and update the `sessions` state. Integrate the `SessionsList` component, passing `sessions`, `loading`, and `error` props.
+        *   **Test:** Navigate to the Journal page. Confirm sessions load and display correctly. Verify loading and error states are handled.
+
+---
+
+**Phase 3: Frontend Journal Page - Filter UI**
+*   **Goal:** Implement the minimalist filter toggle and its controls.
+*   **Piecemeal Steps:**
+
+    1.  **Create `JournalFilter.jsx` with toggle mechanism and static filter options.**
+        *   **Action:** Create `frontend/src/components/JournalFilter.jsx` with the toggle logic and static dropdowns/inputs for region, swell height, period, and direction.
+        *   **Test:** Verify the component renders correctly. Click the toggle button and confirm it expands/collapses.
+
+    2.  **Integrate `JournalFilter.jsx` into `JournalPage.jsx`.**
+        *   **Action:** Import and render `JournalFilter.jsx` in `JournalPage.jsx`.
+        *   **Test:** Verify the filter component is visible on the Journal page.
+
+---
+
+**Phase 4: Frontend Journal Page - Filter Logic & API Integration**
+*   **Goal:** Make the filters functional and update the URL.
+*   **Piecemeal Steps:**
+
+    1.  **Fetch regions and populate "Region" filter in `JournalFilter.jsx`.**
+        *   **Action:** In `JournalFilter.jsx` (or `JournalPage.jsx` and pass down), fetch regions from `/api/regions` and populate the "Region" dropdown.
+        *   **Test:** Verify the "Region" dropdown is populated with actual regions.
+
+    2.  **Implement state management for filters in `JournalPage.jsx` and pass to `JournalFilter.jsx`.**
+        *   **Action:** In `JournalPage.jsx`, manage filter state. Pass filter values and an `onFilterChange` handler to `JournalFilter.jsx`.
+        *   **Test:** Interact with filter controls. Verify filter values can be selected/entered and their state is correctly managed in `JournalPage.jsx`.
+
+    3.  **Modify session fetching to include filter parameters.**
+        *   **Action:** Update the `useEffect` in `JournalPage.jsx` to include the current filter values as query parameters when calling the `/users/:userId/sessions` endpoint.
+        *   **Test:** Apply various filters (e.g., min swell height, region). Verify that the displayed sessions change accordingly.
+
+    4.  **Update URL with filter parameters.**
+        *   **Action:** Use `react-router-dom`'s `useSearchParams` hook in `JournalPage.jsx` to reflect the active filters in the URL.
+        *   **Test:** Apply filters. Verify the URL updates (e.g., `.../journal/me?min_swell_height=3&region=East%20Coast`). Refresh the page and confirm filters persist.

--- a/database_utils.py
+++ b/database_utils.py
@@ -856,6 +856,10 @@ def get_session_summary_list(viewer_id, profile_user_id_filter=None, filters={})
 
             query += " ORDER BY s.created_at DESC"
 
+            print(f"DEBUG: get_session_summary_list - profile_user_id_filter: {profile_user_id_filter}, viewer_id: {viewer_id}")
+            print(f"DEBUG: get_session_summary_list - SQL Query: {query}")
+            print(f"DEBUG: get_session_summary_list - Query Params: {params}")
+
             cur.execute(query, tuple(params))
             sessions = cur.fetchall()
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate
-} from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import AuthPage from './pages/Auth.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -47,8 +42,9 @@ const AppContent = () => {
               </ProtectedRoute>
             }
           />
+          <Route path="/journal" element={<Navigate to="/journal/me" replace />} />
           <Route
-            path="/journal"
+            path="/journal/:userId"
             element={
               <ProtectedRoute>
                 <JournalPage />

--- a/frontend/src/components/PageTabs.jsx
+++ b/frontend/src/components/PageTabs.jsx
@@ -4,11 +4,24 @@ import { Link, useLocation } from 'react-router-dom';
 const PageTabs = ({ tabs }) => {
   const location = useLocation();
 
-  const getTabClasses = (path) => {
+  const getTabClasses = (tabPath) => {
     const baseClasses = "flex-1 px-4 py-2 text-center rounded-tl-md rounded-tr-md";
     const activeClasses = "bg-blue-600 text-white";
     const inactiveClasses = "bg-gray-200 text-gray-800 hover:bg-gray-300";
-    return `${baseClasses} ${location.pathname + location.search === path ? activeClasses : inactiveClasses}`;
+
+    const currentPathname = location.pathname;
+    const currentSearchParams = new URLSearchParams(location.search);
+    const currentTabParam = currentSearchParams.get('tab') || 'log'; // Default to 'log'
+
+    const tabUrl = new URL(`http://dummy.com${tabPath}`); // Use a dummy base URL to parse the path
+    const tabPathname = tabUrl.pathname;
+    const tabSearchParams = new URLSearchParams(tabUrl.search);
+    const tabTabParam = tabSearchParams.get('tab') || 'log'; // Default to 'log'
+
+    // Check if pathnames match AND tab parameters match
+    const isActive = currentPathname === tabPathname && currentTabParam === tabTabParam;
+
+    return `${baseClasses} ${isActive ? activeClasses : inactiveClasses}`;
   };
 
   return (

--- a/frontend/src/components/SessionsList.jsx
+++ b/frontend/src/components/SessionsList.jsx
@@ -1,32 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { apiCall } from '../services/api';
-import Spinner from './UI/Spinner'; // Import Spinner
-import SessionTile from './SessionTile'; // Import SessionTile
+import React from 'react';
+import Spinner from './UI/Spinner';
+import SessionTile from './SessionTile';
 
-const SessionsList = () => {
-  const [sessions, setSessions] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    const fetchSessions = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const response = await apiCall('/api/surf-sessions');
-        console.log('Fetched sessions:', response.data);
-        setSessions(response.data);
-      } catch (err) {
-        console.error('Error fetching sessions:', err);
-        setError(err.message || 'Failed to fetch sessions');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchSessions();
-  }, []);
-
+const SessionsList = ({ sessions, loading, error }) => {
   return (
     <div className="space-y-6">
       {loading && (

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -1,47 +1,38 @@
-import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import PageTabs from '../components/PageTabs'; // Import PageTabs
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { apiCall } from '../services/api';
 
-const JournalPage = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const queryParams = new URLSearchParams(location.search);
-  const currentTab = queryParams.get('tab') || 'log'; // Default to 'log'
+function JournalPage() {
+  const { userId } = useParams();
+  const [profileUser, setProfileUser] = useState(null);
+  const [sessions, setSessions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  // Define tabs for JournalPage
-  const journalTabs = [
-    { label: 'My Sessions', path: '/journal?tab=log' },
-    { label: 'My Stats', path: '/journal?tab=stats' },
-  ];
+  useEffect(() => {
+    // Fetching logic will be added in later steps
+    setLoading(false);
+  }, [userId]);
+
+  if (loading) {
+    // A spinner component could be used here
+    return <div>Loading journal...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500 text-center p-4">Error: {error}</div>;
+  }
 
   return (
-    <div className="bg-gray-100 min-h-screen py-8"> {/* Adjusted root div */} 
-      {/* PageTabs component will be fixed at the top, so main content needs padding */}
-      <main className="max-w-2xl mx-auto space-y-6 px-4 pt-16"> {/* Main content wrapper with pt-16 */} 
-        {/* Page Header / Sub-Navigation - now handled by PageTabs */}
-        <PageTabs tabs={journalTabs} />
-
-        {/* Conditional Content */}
-        <div className="w-full bg-white p-6 rounded-lg shadow-md"> {/* Main content card */} 
-          {currentTab === 'log' && (
-            <div>
-              <h3 className="text-xl font-semibold mb-2">My Sessions Log</h3>
-              <p>This is where your surf sessions will be displayed.</p>
-              {/* SessionsList component will go here eventually */}
-            </div>
-          )}
-
-          {currentTab === 'stats' && (
-            <div>
-              <h3 className="text-xl font-semibold mb-2">My Aggregated Stats</h3>
-              <p>This is where your personal surf statistics will be displayed.</p>
-              {/* Stats components will go here eventually */}
-            </div>
-          )}
-        </div>
-      </main>
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">
+        Journal
+      </h1>
+      <div>
+        <p>Sessions will be displayed here soon.</p>
+      </div>
     </div>
   );
-};
+}
 
 export default JournalPage;

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -1,22 +1,49 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { apiCall } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import Spinner from '../components/UI/Spinner';
 
 function JournalPage() {
   const { userId } = useParams();
+  const { user: currentUser } = useAuth();
   const [profileUser, setProfileUser] = useState(null);
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    // Fetching logic will be added in later steps
-    setLoading(false);
-  }, [userId]);
+    const fetchProfile = async () => {
+      // If we're on the 'me' page, wait for the currentUser object to be loaded.
+      if (userId === 'me' && !currentUser) {
+        return; // The effect will re-run when currentUser is available.
+      }
 
-  if (loading) {
-    // A spinner component could be used here
-    return <div>Loading journal...</div>;
+      try {
+        setLoading(true);
+        const effectiveUserId = userId === 'me' ? currentUser.id : userId;
+
+        if (!effectiveUserId) {
+          setError("User not found.");
+          setLoading(false);
+          return;
+        }
+
+        const profileResponse = await apiCall(`/api/users/${effectiveUserId}/profile`);
+        setProfileUser(profileResponse.data);
+        setLoading(false);
+      } catch (err) {
+        setError('Failed to fetch user profile.');
+        console.error(err);
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [userId, currentUser]);
+
+  if (loading && !profileUser) {
+    return <Spinner />;
   }
 
   if (error) {
@@ -26,7 +53,7 @@ function JournalPage() {
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">
-        Journal
+        {profileUser ? `${profileUser.display_name}'s Journal` : 'Journal'}
       </h1>
       <div>
         <p>Sessions will be displayed here soon.</p>

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { apiCall } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import Spinner from '../components/UI/Spinner';
+import SessionsList from '../components/SessionsList';
 
 function JournalPage() {
   const { userId } = useParams();
@@ -13,7 +14,7 @@ function JournalPage() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const fetchProfile = async () => {
+    const fetchData = async () => {
       // If we're on the 'me' page, wait for the currentUser object to be loaded.
       if (userId === 'me' && !currentUser) {
         return; // The effect will re-run when currentUser is available.
@@ -29,17 +30,23 @@ function JournalPage() {
           return;
         }
 
+        // Fetch profile data
         const profileResponse = await apiCall(`/api/users/${effectiveUserId}/profile`);
         setProfileUser(profileResponse.data);
+
+        // Fetch sessions data
+        const sessionsResponse = await apiCall(`/api/users/${effectiveUserId}/sessions`);
+        setSessions(sessionsResponse.data);
+
         setLoading(false);
       } catch (err) {
-        setError('Failed to fetch user profile.');
+        setError('Failed to fetch data.');
         console.error(err);
         setLoading(false);
       }
     };
 
-    fetchProfile();
+    fetchData();
   }, [userId, currentUser]);
 
   if (loading && !profileUser) {
@@ -56,7 +63,7 @@ function JournalPage() {
         {profileUser ? `${profileUser.display_name}'s Journal` : 'Journal'}
       </h1>
       <div>
-        <p>Sessions will be displayed here soon.</p>
+        <SessionsList sessions={sessions} loading={loading} error={error} />
       </div>
     </div>
   );

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -18,11 +18,6 @@ function JournalPage() {
   const queryParams = new URLSearchParams(location.search);
   const currentTab = queryParams.get('tab') || 'log'; // Default to 'log'
 
-  const journalTabs = [
-    { label: 'Log', path: `/journal/${userId}?tab=log` },
-    { label: 'My Stats', path: `/journal/${userId}?tab=stats` },
-  ];
-
   useEffect(() => {
     const fetchData = async () => {
       // If we're on the 'me' page, wait for the currentUser object to be loaded.
@@ -68,6 +63,21 @@ function JournalPage() {
   if (error) {
     return <div className="text-red-500 text-center p-4">Error: {error}</div>;
   }
+
+  // Determine the prefix for tab labels dynamically
+  let journalOwnerPrefix = 'Journal'; // Default fallback
+  if (profileUser) {
+    if (userId === 'me' || (currentUser && profileUser.id === currentUser.id)) {
+      journalOwnerPrefix = 'My';
+    } else {
+      journalOwnerPrefix = `${profileUser.display_name}'s`;
+    }
+  }
+
+  const journalTabs = [
+    { label: `${journalOwnerPrefix} Log`, path: `/journal/${userId}?tab=log` },
+    { label: `${journalOwnerPrefix} Stats`, path: `/journal/${userId}?tab=stats` },
+  ];
 
   return (
     <div className="container mx-auto p-4 pt-16">

--- a/surfdata.py
+++ b/surfdata.py
@@ -4,7 +4,7 @@ from flask_caching import Cache
 from datetime import datetime, timezone, timedelta
 import surfpy
 import database_utils
-from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions
+from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions, get_user_profile_by_id
 import json
 from json_utils import CustomJSONEncoder
 import math
@@ -689,6 +689,29 @@ def search_users(user_id):
             
     except Exception as e:
         print(f"Error in user search: {str(e)}")
+        return jsonify({"status": "error", "message": f"An error occurred: {str(e)}"}), 500
+
+@app.route('/api/users/<string:user_id>/profile', methods=['GET'])
+@token_required
+def get_user_profile(current_user_id, user_id):
+    """
+    Get a user's public profile information by user ID.
+    """
+    try:
+        # Allow 'me' as an alias for the current user
+        if user_id == 'me':
+            user_id = current_user_id
+
+        user_profile = database_utils.get_user_profile_by_id(user_id)
+        
+        if not user_profile:
+            return jsonify({"status": "fail", "message": "User not found"}), 404
+            
+        return jsonify({"status": "success", "data": user_profile}), 200
+    except Exception as e:
+        print(f"Error retrieving user profile: {str(e)}")
+        import traceback
+        traceback.print_exc()
         return jsonify({"status": "error", "message": f"An error occurred: {str(e)}"}), 500
 
 @app.route('/api/users/<string:profile_user_id>/sessions', methods=['GET'])

--- a/surfdata.py
+++ b/surfdata.py
@@ -726,6 +726,8 @@ def get_user_journal_sessions(viewer_user_id, profile_user_id):
         if profile_user_id == 'me':
             profile_user_id = viewer_user_id
 
+        print(f"DEBUG: get_user_journal_sessions - viewer_user_id: {viewer_user_id}, profile_user_id: {profile_user_id}")
+
         # Extract filter parameters from the request
         filters = {
             'min_swell_height': request.args.get('min_swell_height', type=float),


### PR DESCRIPTION
### Implemented the basic journal page
- Displays the username of whoever's journal you're looking at 
- Tabs say "User log" and "User stats" 
- sessions are filtered for the user you are viewing

### Some structural changes to note: 
1. created an endpoint on the backend to return user information based on the UUID. This is used to display Display Names
2. The session list component is now "dumb"

  ### 
gemini explanation of dumb components 
In React, we often categorize components as "smart" (or container) and "dumb" (or presentational).

   * Smart Components (like `JournalPage` and `Feed` now are):
       * Are responsible for how things work.
       * Manage state, fetch data (e.g., make API calls), and contain complex logic.
       * They "know" about the application's data and business rules.
       * They pass data and functions down to their dumb children via props.

   * Dumb Components (like `SessionsList` now is):
       * Are responsible for how things look.
       * Receive all their data and functions exclusively through props.
       * They have no internal state related to data or complex logic.
       * They don't "know" where the data comes from or what it means; they just display it.

  What happened with `SessionsList`:

  Originally, SessionsList was a "smart" component. It had its own internal state (useState) for sessions, loading, and error, and it performed
  its own data fetching (useEffect making an apiCall to /api/surf-sessions). This meant it always fetched all sessions, regardless of where it
  was used.

  When we tried to use it in the Journal page, JournalPage was fetching user-specific sessions, but SessionsList was ignoring those and fetching
  all sessions again, leading to the filtering issue.

  The "Dumb" Refactor:

  We refactored SessionsList to be a "dumb" component:
   1. We removed its internal state and data-fetching logic.
   2. It now accepts sessions, loading, and error directly as props.
   3. Its rendering logic simply displays whatever sessions it receives.

  The Impact:

  Now, SessionsList is a highly reusable component.
   * JournalPage (a smart component) fetches only the current user's sessions and passes them to SessionsList.
   * Feed.jsx (also a smart component) fetches all sessions and passes them to SessionsList.

  This separation of concerns makes the code cleaner, easier to understand, and more maintainable. SessionsList is now just a display component,
  and the parent components (JournalPage, Feed) are responsible for deciding what data SessionsList should display.


### Left To-Do: 
- Filtering
- stats page 

### Gemini: 

✦ feat: Complete Journal Page Basic Display and Refactor Session Lists
 
This pull request completes Phase 1 and Phase 2 of the Journal Page Implementation Plan, delivering a functional basic Journal page with dynamic content.

Key changes include:
 
- **Backend API Foundation (Phase 1):** Verified and ensured all necessary backend endpoints for user profiles and sessions are functional.

- **Journal Page Basic Display (Phase 2):**
- Implemented core `JournalPage.jsx` structure and routing.
- Enabled fetching and displaying of user profile information, including dynamic `display_name`.
 - Integrated session display using `SessionsList`.
 - **Refactored `SessionsList` to be a "dumb" presentational component**, accepting data via props, enhancing reusability.
- **Updated `Feed.jsx` to fetch its own session data** and pass it to the refactored `SessionsList`, maintaining Feed page
      functionality.
- **Implemented dynamic page tabs ("Log" / "My Stats")** on the Journal page, with labels adapting based on the journal owner (e.g., "My Log" or "Martin's Log").
 - Addressed several bugs encountered during development, including `AuthContext` import issues, incorrect API response parsing for user profiles, and `PageTabs` active state logic. This work lays a solid foundation for future Journal page features, including filtering and stats display.
