### PR TITLE
Stats page

### DIFF
--- a/JOURNAL_STATS_PLAN.md
+++ b/JOURNAL_STATS_PLAN.md
@@ -1,0 +1,35 @@
+# Journal Page Stats Feature Plan
+
+This document outlines the plan to implement the "Stats" tab on the user Journal page. The implementation will be broken into two main phases: Backend and Frontend.
+
+## Backend Plan
+
+1.  **Create a New Stats Database Function:**
+    *   In `database_utils.py`, create a new function: `get_user_stats(user_id)`.
+    *   This function will calculate and return aggregate statistics for the specified `user_id`.
+    *   The function will compute the following metrics:
+        *   `total_sessions`: The total count of surf sessions for the user.
+        *   `total_surf_time`: The sum of the duration of all sessions.
+        *   `average_fun_rating`: The average of the `fun_rating` across all sessions.
+
+2.  **Create a New API Endpoint:**
+    *   In `surfdata.py`, add a new route: `/api/users/<string:profile_user_id>/stats`.
+    *   This endpoint will be protected and will call the `get_user_stats(profile_user_id)` function.
+    *   It will return a JSON object with the three calculated statistics.
+
+## Frontend Plan
+
+1.  **Update `JournalPage.jsx` Data Fetching:**
+    *   Introduce new state variables: `stats`, `statsLoading`, and `statsError`.
+    *   Modify the main `useEffect` hook to fetch data from the new `/api/users/<user_id>/stats` endpoint when the `currentTab` is 'stats'.
+    *   Store the fetched data in the `stats` state.
+
+2.  **Create `StatsDisplay.jsx` Component:**
+    *   Create a new reusable component at `frontend/src/components/StatsDisplay.jsx`.
+    *   This component will accept `stats`, `loading`, and `error` as props.
+    *   It will be responsible for rendering the three key statistics in a clear and user-friendly way (e.g., in separate `Card` components).
+    *   It will handle displaying a loading spinner or an error message as needed.
+
+3.  **Integrate into `JournalPage.jsx`:**
+    *   In the render function of `JournalPage.jsx`, replace the current placeholder for the 'stats' tab with the `<StatsDisplay />` component.
+    *   Pass the `stats`, `statsLoading`, and `statsError` state variables as props to the component.

--- a/frontend/src/components/StatsDisplay.jsx
+++ b/frontend/src/components/StatsDisplay.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Spinner from './UI/Spinner';
+import Card from './UI/Card';
+
+function StatsDisplay({ stats, loading, error }) {
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <div className="text-red-500 text-center p-4">Error: {error}</div>;
+  }
+
+  if (!stats) {
+    return <div className="text-center p-4">No stats available.</div>;
+  }
+
+  // Convert minutes to hours, rounding to one decimal place
+  const hours = stats.total_surf_time_minutes ? (stats.total_surf_time_minutes / 60).toFixed(1) : 0;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-center">
+      <Card>
+        <h3 className="text-lg font-semibold text-gray-600">Total Sessions</h3>
+        <p className="text-4xl font-bold text-gray-800">{stats.total_sessions || 0}</p>
+      </Card>
+      <Card>
+        <h3 className="text-lg font-semibold text-gray-600">Total Surf Time</h3>
+        <p className="text-4xl font-bold text-gray-800">{hours} <span className="text-2xl">hrs</span></p>
+      </Card>
+      <Card>
+        <h3 className="text-lg font-semibold text-gray-600">Average Fun</h3>
+        <p className="text-4xl font-bold text-gray-800">{stats.average_fun_rating || 'N/A'}</p>
+      </Card>
+    </div>
+  );
+}
+
+export default StatsDisplay;

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -125,7 +125,9 @@ function JournalPage() {
     <div className="bg-gray-100 min-h-screen py-8">
       <main className="max-w-2xl mx-auto px-4 pt-16">
         <h1 className="text-2xl font-bold mb-6">
-          {profileUser ? `${profileUser.display_name}'s Journal` : 'Journal'}
+          {profileUser 
+            ? `${profileUser.display_name}'s ${currentTab === 'stats' ? 'Stats' : 'Journal'}` 
+            : (currentTab === 'stats' ? 'Stats' : 'Journal')}
         </h1>
         
         <PageTabs tabs={journalTabs} />

--- a/frontend/src/pages/JournalPage.jsx
+++ b/frontend/src/pages/JournalPage.jsx
@@ -6,6 +6,7 @@ import Spinner from '../components/UI/Spinner';
 import SessionsList from '../components/SessionsList';
 import PageTabs from '../components/PageTabs';
 import JournalFilter from '../components/JournalFilter';
+import StatsDisplay from '../components/StatsDisplay'; // Import the new component
 
 // Helper function to parse URL search params into filter state
 const parseSearchParams = (params) => {
@@ -26,6 +27,7 @@ function JournalPage() {
   const { user: currentUser } = useAuth();
   const [profileUser, setProfileUser] = useState(null);
   const [sessions, setSessions] = useState([]);
+  const [stats, setStats] = useState(null); // State for stats data
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -54,13 +56,13 @@ function JournalPage() {
 
   useEffect(() => {
     const fetchData = async () => {
-      // If we're on the 'me' page, wait for the currentUser object to be loaded.
       if (userId === 'me' && !currentUser) {
-        return; // The effect will re-run when currentUser is available.
+        return; 
       }
 
       try {
         setLoading(true);
+        setError(null); // Reset error state
         const effectiveUserId = userId === 'me' ? currentUser.id : userId;
 
         if (!effectiveUserId) {
@@ -69,15 +71,20 @@ function JournalPage() {
           return;
         }
 
-        // Fetch profile data
-        const profileResponse = await apiCall(`/api/users/${effectiveUserId}/profile`);
-        setProfileUser(profileResponse.data);
+        // Fetch profile data if not already fetched
+        if (!profileUser || profileUser.id !== effectiveUserId) {
+          const profileResponse = await apiCall(`/api/users/${effectiveUserId}/profile`);
+          setProfileUser(profileResponse.data);
+        }
 
-        // Fetch sessions data (only if on the 'log' tab)
+        // Fetch data based on the active tab
         if (currentTab === 'log') {
           const queryString = new URLSearchParams(filters).toString();
           const sessionsResponse = await apiCall(`/api/users/${effectiveUserId}/sessions?${queryString}`);
           setSessions(sessionsResponse.data);
+        } else if (currentTab === 'stats') {
+          const statsResponse = await apiCall(`/api/users/${effectiveUserId}/stats`);
+          setStats(statsResponse.data);
         }
 
         setLoading(false);
@@ -89,13 +96,13 @@ function JournalPage() {
     };
 
     fetchData();
-  }, [userId, currentUser, currentTab, filters]); // Add filters to dependencies
+  }, [userId, currentUser, currentTab, filters, profileUser]); // Add profileUser to dependencies
 
   if (loading && !profileUser) {
     return <Spinner />;
   }
 
-  if (error) {
+  if (error && !profileUser) { // Only show full-page error if profile hasn't loaded
     return <div className="text-red-500 text-center p-4">Error: {error}</div>;
   }
 
@@ -110,8 +117,8 @@ function JournalPage() {
   }
 
   const journalTabs = [
-    { label: `${journalOwnerPrefix} Log`, path: `/journal/${userId}?tab=log` },
-    { label: `${journalOwnerPrefix} Stats`, path: `/journal/${userId}?tab=stats` },
+    { label: `${journalOwnerPrefix} Log`, path: `/journal/${userId || 'me'}?tab=log` },
+    { label: `${journalOwnerPrefix} Stats`, path: `/journal/${userId || 'me'}?tab=stats` },
   ];
 
   return (
@@ -131,9 +138,8 @@ function JournalPage() {
         )}
 
         {currentTab === 'stats' && (
-          <div className="w-full bg-white p-6 rounded-lg shadow-md text-center">
-            <p>This is the stats section for {profileUser ? profileUser.display_name : 'this user'}.</p>
-            {/* Stats component will go here eventually */}
+          <div className="w-full bg-white p-6 rounded-lg shadow-md">
+            <StatsDisplay stats={stats} loading={loading} error={error} />
           </div>
         )}
       </main>

--- a/surfdata.py
+++ b/surfdata.py
@@ -4,7 +4,7 @@ from flask_caching import Cache
 from datetime import datetime, timezone, timedelta
 import surfpy
 import database_utils
-from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions, get_user_profile_by_id
+from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions, get_user_profile_by_id, get_user_stats
 import json
 from json_utils import CustomJSONEncoder
 import math
@@ -755,6 +755,29 @@ def get_user_journal_sessions(viewer_user_id, profile_user_id):
         import traceback
         print(traceback.format_exc())
         return jsonify({"status": "fail", "message": f"Error retrieving user sessions: {str(e)}"}), 500
+
+@app.route('/api/users/<string:profile_user_id>/stats', methods=['GET'])
+@token_required
+def get_user_stats_route(viewer_user_id, profile_user_id):
+    """
+    Get statistics for a specific user.
+    Handles 'me' as an alias for the authenticated user.
+    """
+    try:
+        # Handle 'me' alias
+        if profile_user_id == 'me':
+            profile_user_id = viewer_user_id
+
+        stats = get_user_stats(profile_user_id)
+        
+        if stats is None:
+            return jsonify({"status": "fail", "message": "Failed to retrieve user stats"}), 500
+            
+        return jsonify({"status": "success", "data": stats}), 200
+    except Exception as e:
+        import traceback
+        print(traceback.format_exc())
+        return jsonify({"status": "error", "message": f"An error occurred while fetching stats: {str(e)}"}), 500
 
 
 


### PR DESCRIPTION
- Created new endpoint to get simple user stats
- Implemented into frontend

Gemini

Summary:

  This pull request introduces the "Stats" tab on the user journal page. This feature provides users with an at-a-glance summary of their
  surfing activity, including total sessions, total time spent surfing, and their average fun rating.

  Changes:

   * Backend (`surfdata.py`, `database_utils.py`):
       * A new API endpoint /api/users/<user_id>/stats was created to efficiently query and return aggregate statistics for any user.
       * Added the get_user_stats() database function to perform the aggregation, reducing the load on the database and the amount of data sent to
         the client.

   * Frontend (`JournalPage.jsx`, `StatsDisplay.jsx`):
       * Created the new StatsDisplay.jsx component to present the statistics in a clean, card-based layout.
       * Updated JournalPage.jsx to fetch from the new /stats endpoint when the corresponding tab is active.
       * The page title is now dynamic, correctly switching between "{User}'s Journal" and "{User}'s Stats".

   * Documentation:
       * Added JOURNAL_STATS_PLAN.md to document the implementation plan for this feature.

  How to Test:

   1. Navigate to any user's journal page (e.g., /journal/me).
   2. Click on the "Stats" tab.
   3. Verify that the total sessions, total surf time, and average fun rating are displayed correctly.
   4. Confirm that the main page title updates to reflect the active tab.