### PR TITLE
Leaderboard

### DIFF
--- a/GEMINI_FRONTEND_PLAN.md
+++ b/GEMINI_FRONTEND_PLAN.md
@@ -43,6 +43,8 @@ This document provides a systematic plan for building the SLAPP frontend using G
 │   ├── Navigation.jsx      # App navigation with bottom nav
 │   ├── UserSearch.jsx      # Search overlay/modal
 │   ├── ShakaModal.jsx      # Users who reacted modal
+│   ├── StatsDisplay.jsx    # Renders user stats on Journal page
+│   ├── Leaderboard.jsx     # Renders community leaderboard on Feed page
 │   └── UI/                 # Basic UI components (buttons, inputs, filters)
 ├── pages/              # Main application pages
 │   ├── Auth.jsx           # Login/signup page
@@ -227,12 +229,13 @@ The following foundational tasks have been completed, ensuring consistency, reus
   - Edit/delete functionality for session owners
   - Shaka reactions with modal integration
 
-- **Journal Pages**:
-  - Flexible component works for any user (self or friends)
-  - Log/Stats tab switching within same page
-  - Filtering controls for surf conditions and regions
-  - User context handling (me vs others)
-  - URL parameter support for filters
+- **Journal Pages**: ✅ **Complete**
+  - **Completed**:
+    - A flexible component that works for any user (the logged-in user or others).
+    - Implemented tab switching for `Log` and `Stats` views within the same page, driven by URL query parameters.
+    - The `Stats` tab now fetches data from a dedicated `/api/users/:id/stats` endpoint.
+    - A new `StatsDisplay.jsx` component renders the aggregate data (total sessions, time, and average rating).
+    - The page title is dynamic, updating to reflect the active tab (e.g., "User's Stats").
 
 ### API Integration
 - Backend surf spot data with regional organization
@@ -240,6 +243,7 @@ The following foundational tasks have been completed, ensuring consistency, reus
 - Complete session CRUD operations
 - User session history with filtering capabilities
 - Individual session details with full surf data
+- **New**: Dedicated user stats endpoint (`/api/users/:id/stats`).
 
 ### Success Criteria
 - Complete session CRUD functionality
@@ -257,12 +261,11 @@ The following foundational tasks have been completed, ensuring consistency, reus
 - Implement reaction and leaderboard systems
 
 ### Features to Build
-- **Session Feed**:
-  - Community session display using SessionsList
-  - Feed/Leaderboard tab switching within same page
-  - Pull-to-refresh and infinite scroll
-  - Social context and user attribution
-  - Clickable usernames navigate to their journals
+- **Session Feed**: ✅ **Complete**
+  - **Completed**:
+    - Displays the community session feed using the `SessionsList` component.
+    - Implemented tab switching for the `Feed` and `Leaderboard` views.
+    - The general "Welcome" card has been removed to streamline the UI.
 
 - **User Search Integration**:
   - UserSearch modal integration across app
@@ -276,18 +279,18 @@ The following foundational tasks have been completed, ensuring consistency, reus
   - User profile links from reaction modal
   - Real-time count updates
 
-- **Leaderboards**:
-  - Community rankings by sessions, surf time, fun rating
-  - Tab switching within Feed page
-  - Year selection and filtering capabilities
-  - Current user highlighting in rankings
+- **Leaderboards**: ✅ **Complete**
+  - **Completed**:
+    - A new `Leaderboard.jsx` component encapsulates all leaderboard logic.
+    - It fetches data from a new, dedicated `/api/leaderboard` endpoint for efficiency.
+    - Includes dropdowns to filter the leaderboard by year and by statistic (sessions, time, rating).
+    - The currently logged-in user's entry is highlighted in the list for easy visibility.
 
 ### API Integration
 - Community session feeds with filtering support
 - Shaka reaction toggle and user lists
 - User search and discovery functionality
-- User session history across all users
-- Community statistics and leaderboard data
+- **New**: Dedicated leaderboard endpoint (`/api/leaderboard`) with filtering.
 
 ### Success Criteria
 - Social features encourage community engagement
@@ -404,15 +407,16 @@ const apiCall = async (endpoint, options = {}) => {
 
 ### Session Management ✅
 - [x] Session creation flow
+- [x] Journal pages and stats
 - [ ] Session detail views
 - [ ] Session editing functionality
 - [ ] API integration complete
 
 ### Social Features ✅  
-- [ ] Session feed and community view
+- [x] Session feed and community view
+- [x] Leaderboards and statistics
 - [ ] Shaka reactions system
 - [ ] User discovery and profiles
-- [ ] Leaderboards and statistics
 
 ### Integration & Polish ✅
 - [ ] Complete API integration

--- a/GEMINI_FRONTEND_PLAN.md
+++ b/GEMINI_FRONTEND_PLAN.md
@@ -43,6 +43,9 @@ This document provides a systematic plan for building the SLAPP frontend using G
 │   ├── Navigation.jsx      # App navigation with bottom nav
 │   ├── UserSearch.jsx      # Search overlay/modal
 │   ├── ShakaModal.jsx      # Users who reacted modal
+│   ├── SwellDisplay.jsx    # Renders swell data charts
+│   ├── WindDisplay.jsx     # Renders wind data charts
+│   ├── TideDisplay.jsx     # Renders tide data charts
 │   ├── StatsDisplay.jsx    # Renders user stats on Journal page
 │   ├── Leaderboard.jsx     # Renders community leaderboard on Feed page
 │   └── UI/                 # Basic UI components (buttons, inputs, filters)
@@ -222,12 +225,11 @@ The following foundational tasks have been completed, ensuring consistency, reus
     - Includes form validation, loading/submitting states, and success/error notifications.
     - On successful creation, it redirects the user to the new session's detail page.
 
-- **Session Detail Views**:
-  - Complete session information display
-  - Surf conditions display (swell, wind, tide, temperature)
-  - Clickable participant profiles → navigate to their journals
-  - Edit/delete functionality for session owners
-  - Shaka reactions with modal integration
+- **Session Detail Views**: ✅ **Complete**
+  - **Completed**:
+    - Fetches and displays all information for a single session, including name, location, time, and notes.
+    - Utilizes new dedicated components (`SwellDisplay`, `WindDisplay`, `TideDisplay`) to visualize detailed oceanographic data.
+    - Shows the list of participants, fun rating, and shaka count.
 
 - **Journal Pages**: ✅ **Complete**
   - **Completed**:
@@ -408,7 +410,7 @@ const apiCall = async (endpoint, options = {}) => {
 ### Session Management ✅
 - [x] Session creation flow
 - [x] Journal pages and stats
-- [ ] Session detail views
+- [x] Session detail views
 - [ ] Session editing functionality
 - [ ] API integration complete
 

--- a/LEADERBOARD_PLAN.md
+++ b/LEADERBOARD_PLAN.md
@@ -1,0 +1,34 @@
+# Leaderboard Feature Plan
+
+This document outlines the plan to implement the community Leaderboard, which will be accessible as a tab on the Feed page.
+
+This plan follows a revised approach to create a dedicated, efficient backend endpoint for the leaderboard instead of reusing the broader `/api/dashboard` endpoint.
+
+## Backend Plan
+
+1.  **Create a New Database Function:**
+    *   In `database_utils.py`, create a new function: `get_leaderboard(year=None, stat='sessions')`.
+    *   This function will be responsible for querying and aggregating data specifically for the leaderboard.
+    *   It will group sessions by user and calculate key metrics: total sessions, total surf time, and average fun rating.
+    *   The function will accept parameters to allow filtering by `year` and sorting by a specific `stat` (e.g., 'sessions', 'time').
+    *   The output will be a ranked list of users and their relevant stats.
+
+2.  **Create a New API Endpoint:**
+    *   In `surfdata.py`, add a new, protected route: `/api/leaderboard`.
+    *   The endpoint will accept optional query parameters, such as `?year=2024` and `?stat=sessions`, to pass to the database function.
+    *   It will return a clean, lean JSON array containing only the ranked user data required for the leaderboard.
+
+## Frontend Plan
+
+1.  **Create `Leaderboard.jsx` Component:**
+    *   Create a new component at `frontend/src/components/Leaderboard.jsx`.
+    *   This component will encapsulate all UI and logic for the leaderboard.
+    *   **Data Fetching**: It will call the new `/api/leaderboard` endpoint to get its data.
+    *   **State Management**: It will manage its own state for loading, errors, leaderboard data, and the currently selected filter values (e.g., year).
+    *   **UI**:
+        *   It will feature a dropdown menu to filter the leaderboard by year.
+        *   It will render the data as a ranked list, showing each user's rank, display name, and the relevant statistic.
+        *   The currently logged-in user's position on the leaderboard will be highlighted for easy visibility.
+
+2.  **Integrate into `Feed.jsx`:**
+    *   In `Feed.jsx`, the placeholder content for the "Leaderboard" tab will be replaced with the new `<Leaderboard />` component.

--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import { apiCall } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import Spinner from './UI/Spinner';
+
+const Leaderboard = () => {
+  const { user: currentUser } = useAuth();
+  const [leaderboardData, setLeaderboardData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [stat, setStat] = useState('sessions'); // 'sessions', 'time', or 'rating'
+
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await apiCall(`/api/leaderboard?year=${year}&stat=${stat}`);
+        setLeaderboardData(response.data);
+      } catch (err) {
+        console.error('Error fetching leaderboard:', err);
+        setError(err.message || 'Failed to fetch leaderboard');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLeaderboard();
+  }, [year, stat]);
+
+  const generateYearOptions = () => {
+    const currentYear = new Date().getFullYear();
+    const years = [];
+    for (let i = currentYear; i >= 2023; i--) {
+      years.push(i);
+    }
+    return years;
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <div className="text-red-500 text-center p-4">Error: {error}</div>;
+  }
+
+  const getStatValue = (user) => {
+    if (stat === 'time') return `${(user.total_surf_time_minutes / 60).toFixed(1)} hrs`;
+    if (stat === 'rating') return user.average_fun_rating || 'N/A';
+    return user.total_sessions || 0;
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-xl font-semibold">Community Leaderboard</h3>
+        <div className="flex space-x-2">
+          <select value={stat} onChange={(e) => setStat(e.target.value)} className="p-2 border rounded-md bg-white">
+            <option value="sessions">Sessions</option>
+            <option value="time">Time</option>
+            <option value="rating">Rating</option>
+          </select>
+          <select value={year} onChange={(e) => setYear(e.target.value)} className="p-2 border rounded-md bg-white">
+            {generateYearOptions().map(y => <option key={y} value={y}>{y}</option>)}
+          </select>
+        </div>
+      </div>
+      <ul className="space-y-2">
+        {leaderboardData.map((user, index) => (
+          <li key={user.user_id} className={`p-3 rounded-lg flex items-center justify-between ${currentUser.id === user.user_id ? 'bg-blue-100' : 'bg-gray-50'}`}>
+            <div className="flex items-center">
+              <span className="text-lg font-bold text-gray-500 w-8">{index + 1}</span>
+              <span className="font-semibold text-gray-800">{user.display_name}</span>
+            </div>
+            <span className="text-lg font-bold text-gray-700">{getStatValue(user)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -7,6 +7,7 @@ import SessionsList from '../components/SessionsList';
 import PageTabs from '../components/PageTabs';
 import { apiCall } from '../services/api';
 import Spinner from '../components/UI/Spinner';
+import Leaderboard from '../components/Leaderboard'; // Import Leaderboard
 
 const Feed = () => {
   const { user, logout } = useAuth();
@@ -36,6 +37,9 @@ const Feed = () => {
 
     if (currentTab === 'feed') {
       fetchAllSessions();
+    } else {
+      // For leaderboard tab, loading is handled by the Leaderboard component itself
+      setLoading(false);
     }
   }, [currentTab]);
 
@@ -49,14 +53,6 @@ const Feed = () => {
     navigate('/auth/login');
   };
 
-  if (loading) {
-    return <Spinner />;
-  }
-
-  if (error) {
-    return <div className="text-red-500 text-center p-4">Error: {error}</div>;
-  }
-
   return (
     <div className="bg-gray-100 min-h-screen py-8">
       <main className="max-w-2xl mx-auto space-y-6 px-4 pt-16">
@@ -66,15 +62,14 @@ const Feed = () => {
           {currentTab === 'feed' && (
             <div>
               <h3 className="text-xl font-semibold mb-2">Community Feed</h3>
-              <SessionsList sessions={sessions} loading={loading} error={error} />
+              {loading && <Spinner />}
+              {error && <div className="text-red-500 text-center p-4">Error: {error}</div>}
+              {!loading && !error && <SessionsList sessions={sessions} />}
             </div>
           )}
 
           {currentTab === 'leaderboard' && (
-            <div>
-              <h3 className="text-xl font-semibold mb-2">Community Leaderboard</h3>
-              <p>This is a placeholder for the community leaderboard.</p>
-            </div>
+            <Leaderboard />
           )}
         </div>
 

--- a/frontend/src/pages/Feed.jsx
+++ b/frontend/src/pages/Feed.jsx
@@ -72,19 +72,6 @@ const Feed = () => {
             <Leaderboard />
           )}
         </div>
-
-        <Card>
-          <div className="text-center">
-            <h2 className="text-3xl font-bold">Welcome!</h2>
-            {user && <p className="mt-2 text-gray-600">You are logged in.</p>}
-          </div>
-          <Button
-            onClick={handleLogout}
-            variant="destructive"
-          >
-            Logout
-          </Button>
-        </Card>
       </main>
     </div>
   );

--- a/surfdata.py
+++ b/surfdata.py
@@ -4,7 +4,7 @@ from flask_caching import Cache
 from datetime import datetime, timezone, timedelta
 import surfpy
 import database_utils
-from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions, get_user_profile_by_id, get_user_stats
+from database_utils import get_db_connection, create_session, update_session, get_session_detail, get_all_sessions, get_user_sessions, delete_session, verify_user_session, get_dashboard_stats, get_sessions_by_location, get_all_regions, get_user_profile_by_id, get_user_stats, get_leaderboard
 import json
 from json_utils import CustomJSONEncoder
 import math
@@ -601,6 +601,29 @@ def get_dashboard(user_id):
         
     except Exception as e:
         print(f"Error in dashboard endpoint: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        return jsonify({
+            "status": "error",
+            "message": f"An error occurred: {str(e)}"
+        }), 500
+
+@app.route('/api/leaderboard', methods=['GET'])
+@token_required
+def get_leaderboard_route(user_id):
+    try:
+        year = request.args.get('year', type=int)
+        stat = request.args.get('stat', type=str, default='sessions')
+
+        leaderboard_data = get_leaderboard(year=year, stat=stat)
+
+        if leaderboard_data is None:
+            return jsonify({"status": "fail", "message": "Failed to retrieve leaderboard data"}), 500
+
+        return jsonify({"status": "success", "data": leaderboard_data}), 200
+
+    except Exception as e:
+        print(f"Error in leaderboard endpoint: {str(e)}")
         import traceback
         traceback.print_exc()
         return jsonify({


### PR DESCRIPTION
- created new leaderboard endpoint that provides filters for the year
- implemented on front end
- I also updated the frontend plan 
- outstanding: I should be winning in all the stats

### Gemini
feat: Implement Community Leaderboard

  Summary:

  This pull request introduces a full-featured community leaderboard, accessible via a new "Leaderboard" tab on the Feed page. This feature allows users to see how they rank against others based on various surfing statistics and timeframes.

  This implementation uses a new, dedicated API endpoint for efficiency, rather than reusing the general-purpose dashboard endpoint.

  Changes:

   * Backend (`surfdata.py`, `database_utils.py`):
       * Added a new, dedicated /api/leaderboard endpoint that is optimized for this feature.
       * The endpoint accepts year and stat (sessions, time, rating) query parameters for flexible filtering and sorting.
       * Created the get_leaderboard() database function to efficiently query and rank users.

   * Frontend (`Feed.jsx`, `Leaderboard.jsx`):
       * Created the Leaderboard.jsx component to encapsulate all display logic.
       * Implemented dropdown filters for both year and statistic, allowing for dynamic leaderboard views.
       * The currently logged-in user is now highlighted in the leaderboard for easy visibility.
       * The "Welcome" card was removed from the Feed page to create a cleaner and more focused user interface.

   * Documentation:
       * Added LEADERBOARD_PLAN.md to outline the implementation approach for this feature.

  How to Test:

   1. Navigate to the /feed page.
   2. Click on the "Leaderboard" tab.
   3. Verify that the leaderboard displays correctly, ranking users.
   4. Use the "Year" and "Stat" dropdowns to filter the results and confirm the list updates.
   5. Confirm that your user is highlighted in the list.
   6. Confirm that the old "Welcome!" card is no longer visible on the page.