### PR TITLE
Delete session

### DIFF
--- a/DELETE_SESSION_PLAN.md
+++ b/DELETE_SESSION_PLAN.md
@@ -1,0 +1,46 @@
+# Delete Session Functionality Plan
+
+This document outlines the plan for implementing the "Delete Session" functionality in the Surf App.
+
+## 1. Backend API Endpoint (`surfdata.py`)
+
+*   **Status**: Already exists and is correctly implemented.
+*   **Endpoint**: `DELETE /api/surf-sessions/<int:session_id>`
+*   **Authorization**: Protected by `@token_required`, ensuring only authenticated users can access it.
+*   **Ownership Check**: The `database_utils.delete_session` function securely verifies that the `user_id` from the JWT token matches the `user_id` of the session creator, preventing unauthorized deletions.
+*   **Related Data Deletion**: The database schema has `ON DELETE CASCADE` rules configured for foreign keys in `session_participants` and `session_shakas` tables referencing `surf_sessions_duplicate`. This means that when a session is deleted from `surf_sessions_duplicate`, all associated participant and shaka records are automatically deleted by the database.
+*   **Action**: No changes are needed for this backend endpoint or its associated database function.
+
+## 2. Frontend Implementation (`SessionDetail.jsx` and `services/api.js`)
+
+*   **Goal**: Provide a user interface to trigger the session deletion and handle the process.
+
+*   **Piecemeal Steps**:
+
+    1.  **Add Dummy "Delete Session" Button (Visual Only)**:
+        *   **Location**: Insert a simple `<button>` element with the text "Delete Session" at the bottom of the `SessionDetail.jsx` page, inside the main `div` of the `Card` component.
+        *   **Functionality**: This button will not have any `onClick` handler or associated logic.
+        *   **Visibility**: The button will be visible to all users viewing any session for this step.
+        *   **Styling**: Apply basic Tailwind CSS classes to make it look like a button (e.g., `w-full`, `bg-red-600`, `hover:bg-red-700`, `text-white`, `font-bold`, `py-2`, `px-4`, `rounded-lg`, `focus:outline-none`, `focus:shadow-outline`, `transition`, `duration-150`, `ease-in-out`, `mt-6`).
+        *   **Imports**: Do not add any new import statements in this step.
+
+    2.  **Add API Service Function (`deleteSession`)**:
+        *   Create a new asynchronous function named `deleteSession` in `frontend/src/services/api.js`.
+        *   This function will use `apiCall` to make a `DELETE` request to the backend endpoint (`/api/surf-sessions/<session_id>`). It will take the `session_id` as an argument.
+
+    3.  **Add Frontend Imports and `handleDeleteSession` Function**:
+        *   In `SessionDetail.jsx`, add the necessary `import` statements for `useNavigate` from `react-router-dom`, `toast` from `react-hot-toast`, and `deleteSession` from `../services/api`.
+        *   Also, update the `useAuth` import to destructure `user` (e.g., `const { isAuthenticated, user } = useAuth();`).
+        *   Implement the `handleDeleteSession` function. This function will:
+            *   Prompt the user for confirmation using `window.confirm()`.
+            *   If confirmed, call `deleteSession(id)`.
+            *   Use `toast.promise` for loading, success, and error messages.
+            *   On success, redirect the user to `/journal`.
+
+    4.  **Connect Button and Implement Conditional Visibility**:
+        *   Modify the dummy button in `SessionDetail.jsx` to include an `onClick` handler that calls `handleDeleteSession`.
+        *   Implement conditional rendering for the button: it must only be visible if the logged-in user (`user.id`) matches the session creator's ID (`session.user_id`).
+
+    5.  **User Feedback and Redirection (Refinement)**:
+        *   Ensure `toast.promise` provides clear loading, success, and error messages.
+        *   Confirm redirection to `/journal` after successful deletion.

--- a/frontend/src/pages/SessionDetail.jsx
+++ b/frontend/src/pages/SessionDetail.jsx
@@ -136,7 +136,16 @@ const SessionDetail = () => {
             </div>
           </div>
 
+          {/* Dummy Delete Session Button */}
+          <div className="mt-6">
+            <button
+              className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline transition duration-150 ease-in-out"
+            >
+              Delete Session
+            </button>
           </div>
+
+        </div>
       </Card>
     </div>
   );

--- a/frontend/src/pages/SessionDetail.jsx
+++ b/frontend/src/pages/SessionDetail.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom'; // Import useNavigate
 import { useAuth } from '../context/AuthContext';
 import Card from '../components/UI/Card';
 import Spinner from '../components/UI/Spinner';
 import { format } from 'date-fns';
-import { apiCall } from '../services/api';
+import { apiCall, deleteSession } from '../services/api'; // Import deleteSession
+import toast from 'react-hot-toast'; // Import toast
 
 import SwellDisplay from '../components/SwellDisplay';
 import WindDisplay from '../components/WindDisplay';
@@ -12,7 +13,8 @@ import TideDisplay from '../components/TideDisplay';
 
 const SessionDetail = () => {
   const { id } = useParams();
-  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate(); // Initialize useNavigate
+  const { isAuthenticated, user } = useAuth(); // Get user from AuthContext
 
   // State management
   const [session, setSession] = useState(null);
@@ -55,6 +57,22 @@ const SessionDetail = () => {
     const startTimePart = format(startDate, "h:mm a");
     const endTimePart = format(endDate, "h:mm a");
     return `${datePart}, ${startTimePart} - ${endTimePart}`;
+  };
+
+  const handleDeleteSession = async () => {
+    if (window.confirm('Are you sure you want to delete this session? This action cannot be undone.')) {
+      try {
+        await toast.promise(deleteSession(id), {
+          loading: 'Deleting session...', 
+          success: 'Session deleted successfully!',
+          error: 'Failed to delete session.',
+        });
+        navigate('/journal'); // Redirect to journal page after successful deletion
+      } catch (err) {
+        console.error("Error deleting session:", err);
+        // toast.error is handled by toast.promise
+      }
+    }
   };
 
   if (!isAuthenticated) {
@@ -136,14 +154,17 @@ const SessionDetail = () => {
             </div>
           </div>
 
-          {/* Dummy Delete Session Button */}
-          <div className="mt-6">
-            <button
-              className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline transition duration-150 ease-in-out"
-            >
-              Delete Session
-            </button>
-          </div>
+          {/* Delete Session Button - Only visible to session creator */}
+          {user && session.user_id === user.id && (
+            <div className="mt-6">
+              <button
+                onClick={handleDeleteSession}
+                className="w-full bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg focus:outline-none focus:shadow-outline transition duration-150 ease-in-out"
+              >
+                Delete Session
+              </button>
+            </div>
+          )}
 
         </div>
       </Card>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -79,3 +79,24 @@ export const getSessionShakas = async (sessionId) => {
     throw error;
   }
 };
+
+/**
+ * Delete a surf session
+ * @param {number} sessionId - The ID of the session to delete
+ * @returns {Promise<object>} Response from the API
+ */
+export const deleteSession = async (sessionId) => {
+  console.log(`🗑️ Deleting session ${sessionId}`);
+  
+  try {
+    const response = await apiCall(`/api/surf-sessions/${sessionId}`, {
+      method: 'DELETE'
+    });
+    
+    console.log(`🗑️ Delete session response:`, response);
+    return response;
+  } catch (error) {
+    console.error(`🗑️ Failed to delete session ${sessionId}:`, error);
+    throw error;
+  }
+};


### PR DESCRIPTION
- Added in abiliy to delete session - only for your own session

### Gemini

✦ feat: Implement delete session functionality
 
This PR introduces the ability for users to delete their surf sessions from the application.

Key changes include:
- **Frontend (`frontend/src/services/api.js`)**: Added a `deleteSession` service function to handle the API call for session
      deletion.
- **Frontend (`frontend/src/pages/SessionDetail.jsx`)**:
- Integrated `useNavigate` and `react-hot-toast` for navigation and user feedback.
- Implemented a `handleDeleteSession` function that prompts for user confirmation, calls the `deleteSession` API, provides toast notifications for loading/success/error states, and redirects the user to their journal upon successful deletion.
- Added a "Delete Session" button to the session detail page.
- Ensured the delete button is only visible to the creator of the session, leveraging user authentication context.
 
No backend changes were required as the existing `DELETE /api/surf-sessions/<session_id>` endpoint and `database_utils.delete_session` function were already correctly implemented and utilize `ON DELETE CASCADE` for related data cleanup.